### PR TITLE
fix make incompatibility

### DIFF
--- a/meta-aspeed/recipes-kernel/linux/files/patch-2.6.28.9/0029_fix_make_incompatibility.patch
+++ b/meta-aspeed/recipes-kernel/linux/files/patch-2.6.28.9/0029_fix_make_incompatibility.patch
@@ -1,0 +1,27 @@
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2015-03-26 21:42:34.951721559 +0800
++++ b/Makefile	2015-03-26 21:44:31.303137695 +0800
+@@ -439,10 +439,13 @@
+ include $(srctree)/arch/$(SRCARCH)/Makefile
+ export KBUILD_DEFCONFIG KBUILD_KCONFIG
+ 
+-config %config: scripts_basic outputmakefile FORCE
++config: scripts_basic outputmakefile FORCE
+ 	$(Q)mkdir -p include/linux include/config
+ 	$(Q)$(MAKE) $(build)=scripts/kconfig $@
+ 
++%config: scripts_basic outputmakefile FORCE
++	$(Q)mkdir -p include/linux include/config
++	$(Q)$(MAKE) $(build)=scripts/kconfig $@
+ else
+ # ===========================================================================
+ # Build targets only - this includes vmlinux, arch specific targets, clean
+@@ -1607,7 +1610,7 @@
+ 	$(Q)$(MAKE) $(build)=$(build-dir) $(target-dir)$(notdir $@)
+ 
+ # Modules
+-/ %/: prepare scripts FORCE
++/: prepare scripts FORCE
+ 	$(cmd_crmodverdir)
+ 	$(Q)$(MAKE) KBUILD_MODULES=$(if $(CONFIG_MODULES),1) \
+ 	$(build)=$(build-dir)

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_2.6.28.9.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_2.6.28.9.bb
@@ -25,6 +25,7 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
            file://patch-2.6.28.9/0028-ipv6-Plug-sk_buff-leak-in-ipv6_rcv-net-ipv6-ip6_inpu.patch \
            file://patch-2.6.28.9/0001-bzip2-lzma-library-support-for-gzip-bzip2-and-lzma-d.patch \
            file://patch-2.6.28.9/0002-bzip2-lzma-config-and-initramfs-support-for-bzip2-lz.patch \
+           file://patch-2.6.28.9/0029_fix_make_incompatibility.patch \
           "
 
 S = "${WORKDIR}/git"
@@ -32,7 +33,7 @@ S = "${WORKDIR}/git"
 LINUX_VERSION = "2.6.28.9"
 LINUX_VERSION_EXTENSION ?= "-aspeed"
 
-PR = "r1"
+PR = "r2"
 
 KERNEL_CONFIG_COMMAND = "oe_runmake wedge_defconfig && oe_runmake oldconfig"
 


### PR DESCRIPTION
the errors are:
Makefile:442: *** mixed implicit and normal rules: deprecated syntax
Makefile:1610: *** mixed implicit and normal rules: deprecated syntax

The problem is that we did stuff like this: config %config: ... The solution was simple - the above was split into two with identical prerequisites and commands.