### PR TITLE
Solve i2c-tools svn down and add fbutils dependancy to ipmbd

### DIFF
--- a/common/recipes-core/i2c-tools/i2c-tools_3.1.1.bb
+++ b/common/recipes-core/i2c-tools/i2c-tools_3.1.1.bb
@@ -3,11 +3,10 @@ SECTION = "base"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
-SRCREV = "6235"
-SRC_URI = "svn://lm-sensors.org/svn/i2c-tools/branches/;protocol=http;module=i2c-tools-3.1 \
-          "
+SRCREV = "f216eca1c6ebab20473070dc411cc6cb927a77db"
+SRC_URI = "git://github.com/groeck/i2c-tools.git;protocol=https;branch=i2c-tools-3.1"
 
-S = "${WORKDIR}/i2c-tools-3.1"
+S = "${WORKDIR}/git"
 
 i2ctools = "i2cdetect \
             i2cdump \

--- a/common/recipes-core/ipmbd/ipmbd_0.1.bb
+++ b/common/recipes-core/ipmbd/ipmbd_0.1.bb
@@ -12,7 +12,7 @@ SRC_URI = "file://Makefile \
           "
 
 S = "${WORKDIR}"
-DEPENDS += "libipmi libipmb"
+DEPENDS += "libipmi libipmb fbutils"
 
 binfiles = "ipmbd"
 


### PR DESCRIPTION
The svn repo for i2c-tools can't be accessed anymore. Replace this with the GIT mirror repo on github.

Building ipmbd sometimes causes problems because i2c-dev.h is not available. Add a dependancy on fbutils to make sure this task runs first and makes this file available.