### PR TITLE
fix make incompatibility

### DIFF
--- a/meta-aspeed/recipes-kernel/linux/files/patch-2.6.28.9/0034_fix_make_incompatibility.patch
+++ b/meta-aspeed/recipes-kernel/linux/files/patch-2.6.28.9/0034_fix_make_incompatibility.patch
@@ -1,0 +1,31 @@
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2015-04-15 06:39:46.570753842 +0800
++++ b/Makefile	2015-04-15 06:44:45.318441619 +0800
+@@ -439,10 +439,13 @@
+ include $(srctree)/arch/$(SRCARCH)/Makefile
+ export KBUILD_DEFCONFIG KBUILD_KCONFIG
+ 
+-config %config: scripts_basic outputmakefile FORCE
++config: scripts_basic outputmakefile FORCE
+ 	$(Q)mkdir -p include/linux include/config
+ 	$(Q)$(MAKE) $(build)=scripts/kconfig $@
+ 
++%config: scripts_basic outputmakefile FORCE
++	$(Q)mkdir -p include/linux include/config
++	$(Q)$(MAKE) $(build)=scripts/kconfig $@
+ else
+ # ===========================================================================
+ # Build targets only - this includes vmlinux, arch specific targets, clean
+@@ -1607,7 +1610,11 @@
+ 	$(Q)$(MAKE) $(build)=$(build-dir) $(target-dir)$(notdir $@)
+ 
+ # Modules
+-/ %/: prepare scripts FORCE
++/:prepare scripts FORCE
++	$(cmd_crmodverdir)
++	$(Q)$(MAKE) KBUILD_MODULES=$(if $(CONFIG_MODULES),1) \
++	$(build)=$(build-dir)
++%/:prepare scripts FORCE
+ 	$(cmd_crmodverdir)
+ 	$(Q)$(MAKE) KBUILD_MODULES=$(if $(CONFIG_MODULES),1) \
+ 	$(build)=$(build-dir)

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_2.6.28.9.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_2.6.28.9.bb
@@ -24,12 +24,13 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
            file://patch-2.6.28.9/0002-bzip2-lzma-config-and-initramfs-support-for-bzip2-lz.patch \
            file://patch-2.6.28.9/0032-Create-snapshot-of-OpenBMC.patch \
            file://patch-2.6.28.9/0033-Linux-snapshot-of-OpenBMC-f926614.patch;striplevel=6 \
+           file://patch-2.6.28.9/0034_fix_make_incompatibility.patch \
           "
 
 LINUX_VERSION ?= "2.6.28.9"
 LINUX_VERSION_EXTENSION ?= "-aspeed"
 
-PR = "r1"
+PR = "r2"
 PV = "${LINUX_VERSION}"
 
 include linux-aspeed.inc


### PR DESCRIPTION
the errors are:
Makefile:442: *** mixed implicit and normal rules: deprecated syntax
Makefile:1610: *** mixed implicit and normal rules: deprecated syntax

The problem is that we did stuff like this: config %config: ... The solution was simple - the above was split into two with identical prerequisites and commands.