### PR TITLE
Fixup build errors when the build dir is outside the OE root.

### DIFF
--- a/common/recipes-core/base-files/base-files_%.bbappend
+++ b/common/recipes-core/base-files/base-files_%.bbappend
@@ -14,7 +14,7 @@ do_install_bmc_issue () {
     fi
 
     # found out the source dir
-    dir=$(pwd)
+    dir=${COREBASE}
     while [ -n "$dir" -a "$dir" != "/" -a ! -d "$dir/meta-openbmc/.git" ]; do
         dir=$(dirname $dir)
     done

--- a/meta-aspeed/recipes-bsp/u-boot/u-boot_2016.07.bb
+++ b/meta-aspeed/recipes-bsp/u-boot/u-boot_2016.07.bb
@@ -93,7 +93,7 @@ do_compile () {
     unset CPPFLAGS
 
     # found out the source dir
-    dir=$(pwd)
+    dir=${COREBASE}
     while [ -n "$dir" -a "$dir" != "/" -a ! -d "$dir/meta-openbmc/.git" ]; do
         dir=$(dirname $dir)
     done

--- a/meta-facebook/recipes-extended/rsyslog/rsyslog_8.18.0.bbappend
+++ b/meta-facebook/recipes-extended/rsyslog/rsyslog_8.18.0.bbappend
@@ -14,7 +14,7 @@ do_install_append() {
   install -m 644 ${WORKDIR}/rsyslog.conf ${D}${sysconfdir}/rsyslog.conf
   install -m 644 ${WORKDIR}/rsyslog.logrotate ${D}${sysconfdir}/logrotate.rsyslog
 
-  dir=$(pwd)
+  dir=${COREBASE}
   while [ -n "$dir" -a "$dir" != "/" -a ! -d "$dir/meta-openbmc/.git" ]; do
       dir=$(dirname $dir)
   done


### PR DESCRIPTION
Summary:
Building of u-boot and base-files packages fails
when the build directory is outside the OE root.

bitbake fails with the following error:
| DEBUG: Executing shell function do_install | fatal: Not a git repository: ''

The problem is the same for both the packages where do_install scripts
erroneously assume that the working dir is inside the OE root.

This patch fixes the scripts.