### PR TITLE
Warrior release compatibility

### DIFF
--- a/common/recipes-connectivity/dhcp/dhcp_%.bbappend
+++ b/common/recipes-connectivity/dhcp/dhcp_%.bbappend
@@ -9,7 +9,7 @@ def dhcp_patches(d):
     if distro == 'fido' or distro == 'krogoth':
         return "file://dhclinet_ipv6_addr_missing.patch \
                "
-    elif distro == 'rocko':
+    elif distro == 'rocko' or distro == 'warrior':
         return "file://fix-the-error-on-chmod-chown-when-running-dhclient-script.patch \
                "
     else:

--- a/common/recipes-core/initscripts/files/hostname.sh
+++ b/common/recipes-core/initscripts/files/hostname.sh
@@ -17,7 +17,7 @@ set_hostname() {
   # Set hostname
   hostname $name
   # Reload/Restart any services needing the updated hostname
-  /etc/init.d/syslog reload
+  /etc/init.d/syslog restart
 }
 
 update_hostname() {

--- a/common/recipes-core/initscripts/initscripts_1.0.bbappend
+++ b/common/recipes-core/initscripts/initscripts_1.0.bbappend
@@ -9,5 +9,5 @@ do_install_prepend() {
 }
 
 FILES_${PN} += "${sysconfdir}/init.d/hostname.sh"
-RDEPENDS_${PN} += "bash"
+RDEPENDS_${PN} += "bash iproute2 bind-utils"
 DEPENDS += "update-rc.d-native"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,3 +10,6 @@ BBFILES += "${LAYERDIR}/common/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "openbmc"
 BBFILE_PATTERN_openbmc = "^${LAYERDIR}/"
 BBFILE_PRIORITY_openbmc = "6"
+
+
+LAYERSERIES_COMPAT_openbmc = "warrior"

--- a/meta-aspeed/conf/layer.conf
+++ b/meta-aspeed/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "aspeed"
 BBFILE_PATTERN_aspeed = "^${LAYERDIR}/"
 BBFILE_PRIORITY_aspeed = "7"
+
+LAYERSERIES_COMPAT_aspeed = "warrior"

--- a/meta-facebook/conf/distro/openbmc-fb.conf
+++ b/meta-facebook/conf/distro/openbmc-fb.conf
@@ -132,9 +132,9 @@ DEFAULT_TIMEZONE ?= "America/Los_Angeles"
 # Get the OpenBMC verion
 INHERIT += "openbmc_version"
 
-OPENBMC_FB_DEFAULT_FEATURE = "ext2 ipv6 largefile usbgadget usbhost nfs zeroconf"
+OPENBMC_FB_DEFAULT_FEATURE = "ext2 ipv6 largefile usbgadget usbhost nfs zeroconf ipv4"
 OPENBMC_BOARD_FEATURE ?= ""
-DISTRO_FEATURES = "${DISTRO_FEATURES_LIBC} ${OPENBMC_FB_DEFAULT_FEATURE} ${OPENBMC_BOARD_FEATURE}"
+DISTRO_FEATURES = "${OPENBMC_FB_DEFAULT_FEATURE} ${OPENBMC_BOARD_FEATURE}"
 
 DISTRO_NAME = "Facebook OpenBMC"
 DISTRO_VERSION = "0.4"

--- a/meta-facebook/conf/layer.conf
+++ b/meta-facebook/conf/layer.conf
@@ -8,3 +8,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "facebook"
 BBFILE_PATTERN_facebook = "^${LAYERDIR}/"
 BBFILE_PRIORITY_facebook = "15"
+
+
+LAYERSERIES_COMPAT_facebook = "warrior"

--- a/meta-facebook/meta-python3/conf/layer.conf
+++ b/meta-facebook/meta-python3/conf/layer.conf
@@ -13,3 +13,6 @@ BBFILE_PRIORITY_py3 = "99"
 # Blacklist python2 to prevent image size regression
 PNBLACKLIST[python] = "We use python3 only. Depend on python3 instead"
 PNBLACKLIST[python-core] = "We use python3 only. Depend on python3-core instead"
+
+
+LAYERSERIES_COMPAT_py3 = "warrior"

--- a/meta-facebook/meta-python3/recipes-connectivity/bind/bind_%.bbappend
+++ b/meta-facebook/meta-python3/recipes-connectivity/bind/bind_%.bbappend
@@ -1,3 +1,0 @@
-# Python3 only. Override py2 packages
-RDEPENDS_${PN}_remove = "python-core"
-RDEPENDS_${PN} += " python3-core"

--- a/meta-facebook/meta-python3/recipes-devtools/opkg-utils/opkg-utils_%.bbappend
+++ b/meta-facebook/meta-python3/recipes-devtools/opkg-utils/opkg-utils_%.bbappend
@@ -1,3 +1,13 @@
 # Python3 only. Override py2 packages
 # Complete override of deps here is sub-optimal, but we don't yet have a bitbake STRING_replace method
-PYTHONRDEPS = "python3 python3-shell python3-io python3-math python3-crypt python3-logging python3-fcntl python3-subprocess python3-pickle python3-compression python3-textutils python3-stringold"
+PYTHONRDEPS = "python3 \
+python3-shell \
+python3-io \
+python3-math \
+python3-crypt \
+python3-logging \
+python3-fcntl \
+python3-pickle \
+python3-compression \
+python3-stringold \
+"

--- a/meta-facebook/meta-python3/recipes-devtools/python/python3_%.bbappend
+++ b/meta-facebook/meta-python3/recipes-devtools/python/python3_%.bbappend
@@ -1,6 +1,7 @@
 # Since we are using only python3, let's provide /usr/bin/python as a symlink to python3
 do_install_append() {
-  ln -s /usr/bin/python3 ${D}/usr/bin/python
+  cd ${D}/${bindir}
+  ln -s python3 python
 }
 
-FILES_${PN} += "${bindir}/python3 ${bindir}/python"
+FILES_${PN} += "${bindir}/python*"

--- a/meta-facebook/meta-wedge/conf/layer.conf
+++ b/meta-facebook/meta-wedge/conf/layer.conf
@@ -8,3 +8,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "wedge"
 BBFILE_PATTERN_wedge = "^${LAYERDIR}/"
 BBFILE_PRIORITY_wedge = "20"
+
+
+LAYERSERIES_COMPAT_wedge = "warrior"

--- a/sync_yocto.sh
+++ b/sync_yocto.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-repos="krogoth rocko"
+repos="krogoth rocko warrior"
 
 if [ ! -d ./yocto ]; then
   mkdir ./yocto


### PR DESCRIPTION
Hello,

The following set of patches, provide compatibility to build with the **warrior** branch from **Yocto**.

For obvious reasons this provides many improvements in the system, including many CVEs and fixes from packages such as openssl, busybox, etc.

The system now correctly builds and runs a **kernel version 5.0.7** (linux-yocto)

There are a couple of necessary changes related to python3 because of the upgrade of the manifest generation / python3 packaging system itself (which I personally did on oe-core) [b677787](https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=b6777878ff03c3e956386020a19d11c875c835ae)

initscripts required some changes as well since it should be getting the ip command from iproute2 and not from busybox as it was happening before, also rdepend on dig since it is being used on the hostname script.

DISTRO wise, there was some required changes to DISTRO_FEATURES due to changes in OE-Core.
[9d973d3](https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=9d973d3b4ed8d2ce3c8997dc21603a0952e7ef0e)

Since I don't have hardware available at the moment, I have tested these on qemuarmv5 (qemuarm was moved to qemuarmv5 on warrior [6acb45](https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=6acb45106dafaf6895ad1fb086b6977c256518f6) ) , since it uses the same architecture/tune (arm926ejs) as several machines within the layer such as: mavericks, galaxy, lightning, wedge, wedge100 and yosemite, although it is worth mentioning that qemuarm (v7) does work correctly as well.

AFAIC there could still be some runtime issues, e.g. /mnt/data isnt mounted, like it would when using real hardware (due to the openbmc-utils dependency)

Regards,
Alejandro