### PR TITLE
travis-ci: remove sstate caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ language: c
 git:
   depth: false # needed to get common ancestor to master
 
-cache:
-  directories:
-  - ${HOME}/sstate-cache
-
 addons:
   apt:
     update: true
@@ -78,9 +74,10 @@ script:
   # It is a small hack to allow builds to finish within 50 minutes.
   # The S3 cache is built on an AWS EC2 instance in the fbopenbmc account.
   # Within TravisCI each machine will then maintain a unique cache.
-  - if [ ! -f ${CACHE}/.seed ]; then wget ${CACHE_URI}/sstate-cache.tar; tar -xf sstate-cache.tar -C ${CACHE}; fi
-  - if [ -f sstate-cache.tar ]; then rm sstate-cache.tar; fi
-  - touch ${CACHE}/.seed
+  - mkdir ${CACHE} &&
+    wget ${CACHE_URI}/sstate-cache.tar &&
+    tar -xf sstate-cache.tar -C ${CACHE} &&
+    rm sstate-cache.tar
 
   # Build the image.
   - source ./openbmc-init-build-env ${BOARD} build-${BOARD}


### PR DESCRIPTION
Per https://docs.travis-ci.com/user/caching/#things-not-to-cache
we should not be caching large compiled binaries, which is effectively
what the sstate-cache is.  Currently we are telling TravisCI to "cache"
this build output directory but then never using it and they are tens
of GB in size.  Disable this caching feature and simply download the
latest sstate cache.

Signed-off-by: Patrick Williams <patrickw3@fb.com>