### PR TITLE
fixes issue #110

### DIFF
--- a/common/recipes-core/fw-util/files/system.cpp
+++ b/common/recipes-core/fw-util/files/system.cpp
@@ -79,7 +79,7 @@ string System::version()
     char vers[128] = "NA";
     FILE *fp = fopen("/etc/issue", "r");
     if (fp) {
-      if (fscanf(fp, "OpenBMC Release %s\n", vers) == 1) {
+      if (fscanf(fp, "OpenBMC Release %127s\n", vers) == 1) {
         ret = vers;
       }
       fclose(fp);

--- a/common/recipes-core/fw-util/files/tpm2.cpp
+++ b/common/recipes-core/fw-util/files/tpm2.cpp
@@ -42,7 +42,7 @@ int tpm2_get_ver(char *ver, Tpm2Component *tpm2) {
         break;
       }
     }
-    fclose(fp);
+    pclose(fp);
 
     if (match != true) {
       return FW_STATUS_FAILURE;


### PR DESCRIPTION
Fixes #110 Solution: Add print limitation.

#114 #116 #117  Seems to be false alarms.
However there is a possible memory leak in 
https://github.com/facebook/openbmc/blob/de522bcdf9ea26e52a81b9a4a69326774bb87a07/common/recipes-core/fw-util/files/tpm2.cpp#L45
Opening pipeline should be closed at the end of process.