### PR TITLE
NC-SI Broadcom OEM GetDebugData Support

### DIFF
--- a/common/recipes-core/ncsi-util/files/Makefile
+++ b/common/recipes-core/ncsi-util/files/Makefile
@@ -1,9 +1,13 @@
 # Copyright 2015-present Facebook. All Rights Reserved.
+
+C_SRCS := $(wildcard *.c)
+C_OBJS := ${C_SRCS:.c=.o}
+
 all: ncsi-util
 
 CFLAGS += -Wall -Werror
 
-ncsi-util: ncsi-util.c
+ncsi-util: $(C_OBJS)
 	$(CC) -pthread $(CFLAGS) -std=gnu11 -o $@ $^ $(LDFLAGS)
 
 .PHONY: clean

--- a/common/recipes-core/ncsi-util/files/brcm-ncsi-util.c
+++ b/common/recipes-core/ncsi-util/files/brcm-ncsi-util.c
@@ -1,0 +1,302 @@
+/*
+ *
+ * Copyright 2020-present Facebook. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <time.h>
+#include <arpa/inet.h>
+#include <zlib.h>
+#include <openbmc/ncsi.h>
+#include <openbmc/ncsi-brcm.h>
+
+#include "brcm-ncsi-util.h"
+
+/*
+ * GetDebugData transaction data
+ */
+typedef struct {
+  NCSI_Brcm_Get_Debug_Data_Request req;
+  FILE      *fp;
+  uint16_t  type;
+  uint32_t  crc;
+  uint32_t  total_len;
+  uint32_t  recv_len;
+} Get_Debug_Data_Txn_t;
+
+static int get_debug_data_name_to_type(const char *name)
+{
+  if (!strcasecmp(name, "coredump"))
+    return NCSI_BRCM_GET_DEBUG_DATA_TYPE_CORE_DUMP;
+  else if (!strcasecmp(name, "crashdump"))
+    return NCSI_BRCM_GET_DEBUG_DATA_TYPE_CRASH_DUMP;
+  else
+    return -1;
+}
+
+static void init_get_debug_data_txn(Get_Debug_Data_Txn_t *gdd_txn,
+                                    uint16_t type)
+{
+  memset(gdd_txn, 0, sizeof(*gdd_txn));
+
+  gdd_txn->type = type;
+  gdd_txn->crc = crc32(0L, Z_NULL, 0);
+
+  gdd_txn->req.type = htons(type);
+  gdd_txn->req.op = NCSI_BRCM_GET_DEBUG_DATA_REQ_OP_START_XFER;
+}
+
+static NCSI_NL_RSP_T *send_get_debug_data_req(NCSI_NL_MSG_T *nl_msg,
+                                              Get_Debug_Data_Txn_t *gdd_txn,
+                                              ncsi_util_args_t *util_args)
+{
+  if (ncsi_brcm_create_req_pkt(nl_msg, util_args->channel_id,
+                               NCSI_BRCM_GET_DEBUG_DATA,
+                               sizeof(gdd_txn->req), &gdd_txn->req)) {
+    printf("Error: failed to create packet\n");
+    return NULL;
+  }
+
+  /* Override the netdev if user has specified one */
+  ncsi_util_set_pkt_dev(nl_msg, util_args, NULL);
+
+  /* Send */
+  return send_nl_msg(nl_msg);
+}
+
+static int handle_get_debug_data_resp(NCSI_NL_RSP_T *nl_resp,
+                                      Get_Debug_Data_Txn_t *gdd_txn,
+                                      bool *txn_completed)
+{
+  NCSI_Brcm_Get_Debug_Data_Response *gdd_resp = ncsi_get_brcm_resp(nl_resp);
+  bool is_first;
+  void *data;
+  int data_len;
+  uint32_t resp_crc = 0;
+
+  /*
+   * Check response
+   */
+  /* Check NC-SI response code */
+  if (get_cmd_status(nl_resp) != RESP_COMMAND_COMPLETED) {
+    print_ncsi_completion_codes(nl_resp);
+    return -1;
+  }
+
+  /* Check Broadcom OEM response */
+  if (ncsi_brcm_check_resp(nl_resp, NCSI_BRCM_GET_DEBUG_DATA,
+                           sizeof(*gdd_resp))) {
+    ncsi_brcm_print_resp_brcm_hdr(nl_resp);
+    return -1;
+  }
+
+  /* Check GetDebugData response */
+  is_first = (gdd_txn->req.op == NCSI_BRCM_GET_DEBUG_DATA_REQ_OP_START_XFER);
+  if (ncsi_brcm_check_get_debug_data(nl_resp, gdd_txn->type, is_first)) {
+    ncsi_brcm_print_get_debug_data(nl_resp);
+    return -1;
+  }
+
+  /*
+   * Process response data
+   */
+  data = gdd_resp->debug_data;
+  data_len = nl_resp->hdr.payload_length - sizeof(*gdd_resp);
+
+  if (gdd_resp->op & NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_START) {
+    /* First response, get total debug data length */
+    gdd_txn->total_len = ntohl(*(uint32_t *)data);
+    data += sizeof(uint32_t);
+    data_len -= sizeof(uint32_t);
+    printf("Debug data length: %u\n", gdd_txn->total_len);
+
+    /* Change request op for next packet */
+    gdd_txn->req.op = NCSI_BRCM_GET_DEBUG_DATA_REQ_OP_GET_NEXT;
+  }
+  gdd_txn->req.data_handle = gdd_resp->next_data_handle;
+
+  if (gdd_resp->op & NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_END) {
+    /* Last response, get CRC32 checksum */
+    data_len -= sizeof(uint32_t);
+    resp_crc = ntohl(*(uint32_t *)(data + data_len));
+  }
+
+  if (data_len > 0) {
+    size_t n;
+
+    /* Debug data received */
+    gdd_txn->recv_len += data_len;
+    gdd_txn->crc = crc32(gdd_txn->crc, data, data_len);
+
+    /* Save data to file */
+    n = fwrite(data, 1, data_len, gdd_txn->fp);
+    if (n < data_len) {
+      printf("Error: failed to write %u data bytes to file, rv %d\n",
+             data_len, n);
+      return -1;
+    }
+  }
+
+  /*
+   * Check if transaction is completed
+   */
+  if (gdd_resp->op & NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_END) {
+    if (gdd_txn->recv_len < gdd_txn->total_len) {
+      printf("Warning: transfer ended with %u data received, shorter than "
+             "debug data length %u\n", gdd_txn->recv_len, gdd_txn->total_len);
+    }
+    if (gdd_txn->crc != resp_crc) {
+      printf("Error: calculated crc32 0x%x not match response's 0x%x\n",
+             gdd_txn->crc, resp_crc);
+      return -1;
+    }
+    *txn_completed = true;
+
+  } else if (gdd_txn->recv_len >= gdd_txn->total_len) {
+    printf("Warning: total data received %u exceeds debug data length %u, "
+           "terminate transfer!\n", gdd_txn->recv_len, gdd_txn->total_len);
+    *txn_completed = true;
+  }
+
+  return 0;
+}
+
+static int get_debug_data(int type, const char *file_name,
+                          ncsi_util_args_t *util_args)
+{
+  Get_Debug_Data_Txn_t gdd_txn;
+  NCSI_NL_MSG_T *nl_msg = NULL;
+  NCSI_NL_RSP_T *nl_resp = NULL;
+  bool txn_completed = false;
+  uint32_t percent = 0;
+  int ret = -1;
+
+  init_get_debug_data_txn(&gdd_txn, type);
+
+  /* Open the file */
+  gdd_txn.fp = fopen(file_name, "w+");
+  if (!gdd_txn.fp) {
+    printf("Error: cannot create file %s\n", file_name);
+    goto done;
+  }
+
+  nl_msg = calloc(1, sizeof(*nl_msg));
+  if (!nl_msg) {
+    printf("Error: failed to allocate nl_msg of %d bytes\n", sizeof(*nl_msg));
+    goto done;
+  }
+
+  while (!txn_completed) {
+
+    /* Send and receive */
+    nl_resp = send_get_debug_data_req(nl_msg, &gdd_txn, util_args);
+    if (!nl_resp)
+      break;
+
+    /* Handle response */
+    if (handle_get_debug_data_resp(nl_resp, &gdd_txn, &txn_completed))
+      break;
+
+    /* Print receive progress */
+    percent = ncsi_util_print_progress(gdd_txn.recv_len, gdd_txn.total_len,
+                                       percent, "Received:");
+
+    free(nl_resp);
+    nl_resp = NULL;
+  }
+
+  if (txn_completed) {
+    printf("GetDebugData completed\n");
+    ret = 0;
+  }
+
+done:
+  if (gdd_txn.fp)
+    fclose(gdd_txn.fp);
+  if (nl_msg)
+    free(nl_msg);
+  if (nl_resp)
+    free(nl_resp);
+
+  return ret;
+}
+
+static void brcm_ncsi_util_usage(void)
+{
+  printf("Usage: ncsi-util -m brcm [options]\n\n");
+  printf("       -h             This help\n");
+  ncsi_util_common_usage();
+  printf("       -d [type]      GetDebugData\n");
+  printf("                        coredump  - Core dump\n");
+  printf("                        crashdump - Crash dump\n");
+  printf("       -o [file]      Output file\n");
+  printf("\nSample commands:\n");
+  printf("       ncsi-util -m brcm -d coredump -o /tmp/nic.core\n");
+  printf("       ncsi-util -m brcm -n eth0 -c 0 -d crashdump -o /tmp/nic.crash\n");
+  printf("\n");
+}
+
+int brcm_ncsi_util_handler(int argc, char **argv, ncsi_util_args_t *util_args)
+{
+  int getdbgdata_type = -1;
+  const char *ofile_name = NULL;
+  int ret = -1;
+  int argflag;
+
+  while ((argflag = getopt(argc, argv, "hd:o:" NCSI_UTIL_COMMON_OPT_STR)) != -1)
+  {
+    switch(argflag) {
+    case 'h':
+            brcm_ncsi_util_usage();
+            return 0;
+    case 'd':
+            getdbgdata_type = get_debug_data_name_to_type(optarg);
+            if (getdbgdata_type < 0) {
+              printf("Error: invalid GetDebugData type %s\n", optarg);
+              goto err_exit;
+            }
+            break;
+    case 'o':
+            ofile_name = optarg;
+            break;
+    case NCSI_UTIL_GETOPT_COMMON_OPT_CHARS:
+            // Already handled
+            break;
+    default :
+            goto err_exit;
+    }
+  }
+
+  if (getdbgdata_type >= 0) {
+    if (!ofile_name) {
+      printf("Error: missing output file argument\n");
+      goto err_exit;
+    }
+    return get_debug_data(getdbgdata_type, ofile_name, util_args);
+  }
+
+  /* No command was done. Fall through to show the usage */
+
+err_exit:
+  brcm_ncsi_util_usage();
+  return ret;
+}

--- a/common/recipes-core/ncsi-util/files/brcm-ncsi-util.h
+++ b/common/recipes-core/ncsi-util/files/brcm-ncsi-util.h
@@ -1,0 +1,27 @@
+/*
+ * brcm-ncsi-util.h
+ *
+ * Copyright 2020-present Facebook. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#ifndef _BRCM_NCSI_UTIL_H_
+#define _BRCM_NCSI_UTIL_H_
+
+#include "ncsi-util.h"
+
+int brcm_ncsi_util_handler(int argc, char **argv, ncsi_util_args_t *util_args);
+
+#endif /* _BRCM_NCSI_UTIL_H_ */

--- a/common/recipes-core/ncsi-util/files/ncsi-util.h
+++ b/common/recipes-core/ncsi-util/files/ncsi-util.h
@@ -1,0 +1,81 @@
+/*
+ * ncsi-util.h
+ *
+ * Copyright 2020-present Facebook. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#ifndef _NCSI_UTIL_H_
+#define _NCSI_UTIL_H_
+
+#include <openbmc/ncsi.h>
+
+#define noDEBUG   /* debug printfs */
+
+/*
+ * ncsi-util common command arguments
+ */
+typedef struct {
+  char  *dev_name;            /* If not null, user specified netdev */
+  int   channel_id;           /* NC-SI channel */
+} ncsi_util_args_t;
+
+#define NCSI_UTIL_DEFAULT_DEV_NAME    "eth0"
+
+/*
+ * Command vendor
+ */
+enum {
+  NCSI_UTIL_VENDOR_DMTF = 0,  /* DMTF defined command */
+  NCSI_UTIL_VENDOR_BRCM,      /* Broadcom OEM command */
+  NCSI_UTIL_VENDOR_MAX,
+};
+
+/*
+ * Vendor specific data and functions
+ */
+typedef struct {
+  const char *name;     /* Vendor name used in command line -o option */
+
+  /* Util command handler function */
+  int (*handler)(int argc, char **argv, ncsi_util_args_t *util_args);
+
+} ncsi_util_vendor_t;
+
+
+// Common command line options
+#define NCSI_UTIL_COMMON_OPT_STR    "n:c:l:m:"
+
+// Common getopt characters for switch-case
+#define NCSI_UTIL_GETOPT_COMMON_OPT_CHARS \
+       'n': \
+  case 'c': \
+  case 'l': \
+  case 'm'
+
+
+/* NC-SI netlink send function */
+extern NCSI_NL_RSP_T * (*send_nl_msg)(NCSI_NL_MSG_T *nl_msg);
+
+void ncsi_util_common_usage(void);
+void ncsi_util_set_pkt_dev(NCSI_NL_MSG_T *nl_msg,
+                           const ncsi_util_args_t *util_args,
+                           const char *dflt_dev_name);
+void ncsi_util_init_pkt_by_args(NCSI_NL_MSG_T *nl_msg,
+                               const ncsi_util_args_t *util_args);
+unsigned long ncsi_util_print_progress(unsigned long cur, unsigned long total,
+                                       unsigned long last_percent,
+                                       const char *prefix_str);
+#endif /* _NCSI_UTIL_H_ */

--- a/common/recipes-core/ncsi-util/ncsi-util_0.1.bb
+++ b/common/recipes-core/ncsi-util/ncsi-util_0.1.bb
@@ -8,12 +8,15 @@ LIC_FILES_CHKSUM = "file://ncsi-util.c;beginline=4;endline=16;md5=b395943ba8a071
 
 SRC_URI = "file://Makefile \
            file://ncsi-util.c \
+           file://ncsi-util.h \
+           file://brcm-ncsi-util.c \
+           file://brcm-ncsi-util.h \
           "
 
 S = "${WORKDIR}"
 binfiles = "ncsi-util"
 
-LDFLAGS += "-lpal -lncsi -lpldm -lnl-wrapper"
+LDFLAGS += "-lpal -lncsi -lpldm -lnl-wrapper -lz"
 
 pkgdir = "ncsi-util"
 
@@ -26,8 +29,8 @@ do_install() {
   ln -snf ../fbpackages/${pkgdir}/ncsi-util ${bin}/ncsi-util
 }
 
-DEPENDS += "libpal libncsi libpldm libnl-wrapper"
-RDEPENDS_${PN} += "libpal libncsi libpldm libnl-wrapper"
+DEPENDS += "libpal libncsi libpldm libnl-wrapper zlib"
+RDEPENDS_${PN} += "libpal libncsi libpldm libnl-wrapper zlib"
 
 
 FBPACKAGEDIR = "${prefix}/local/fbpackages"

--- a/common/recipes-lib/ncsi/files/Makefile
+++ b/common/recipes-lib/ncsi/files/Makefile
@@ -1,16 +1,16 @@
 # Copyright 2015-present Facebook. All Rights Reserved.
 lib: libncsi.so
 
-CFLAGS += -Wall -Werror
+C_SRCS := $(wildcard *.c)
+C_OBJS := ${C_SRCS:.c=.o}
 
-libncsi.so: ncsi.o aen.o
-	$(CC) -shared -o libncsi.so ncsi.o aen.o -lc -lrt $(LDFLAGS)
+CFLAGS += -Wall -Werror -fPIC
 
-ncsi.o: ncsi.c
-	$(CC) $(CFLAGS) -fPIC -c -o ncsi.o ncsi.c
+libncsi.so: $(C_OBJS)
+	$(CC) -shared -o libncsi.so $^ -lc -lrt $(LDFLAGS)
 
-aen.o: aen.c
-	$(CC) $(CFLAGS) -fPIC -c -o aen.o aen.c
+$(C_SRCS:.c=.d):%.d:%.c
+	$(CC) $(CFLAGS) $< >$@
 
 .PHONY: clean
 

--- a/common/recipes-lib/ncsi/files/ncsi-brcm.c
+++ b/common/recipes-lib/ncsi/files/ncsi-brcm.c
@@ -1,0 +1,247 @@
+/*
+ * ncsi-brcm.c
+ *
+ * Copyright 2020-present Facebook. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <syslog.h>
+#include <arpa/inet.h>
+#include "ncsi.h"
+#include "ncsi-brcm.h"
+
+const char *ncsi_brcm_cmd_type_to_name(uint8_t cmd_type)
+{
+  switch (cmd_type) {
+    case NCSI_BRCM_GET_DEBUG_DATA:
+      return "GET_DEBUG_DATA";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+int ncsi_brcm_create_req_pkt(NCSI_NL_MSG_T *nl_msg, uint8_t ch, uint8_t cmd,
+                             uint16_t req_len, void *req)
+{
+  NCSI_Brcm_Request_Hdr *req_hdr = req;
+
+  req_hdr->manufacturer_id = htonl(BCM_IANA);
+  req_hdr->brcm_payload_ver = NCSI_BRCM_PAYLOAD_VERSION;
+  req_hdr->brcm_cmd_type = cmd;
+  req_hdr->brcm_payload_len = htons(req_len - sizeof(*req_hdr));
+  req_hdr->reserved = 0;
+
+  return create_ncsi_ctrl_pkt(nl_msg, ch, NCSI_OEM_CMD, req_len, req);
+}
+
+int ncsi_brcm_check_resp_type(NCSI_NL_RSP_T *nl_resp, uint8_t brcm_cmd_type)
+{
+  NCSI_Brcm_Response_Hdr *resp_hdr = ncsi_get_brcm_resp(nl_resp);
+  uint32_t oem_iana;
+
+  if (nl_resp->hdr.cmd != NCSI_OEM_CMD) {
+    ncsi_log(LOG_ERR, "Error: not ncsi oem response 0x%x", nl_resp->hdr.cmd);
+    return -1;
+  }
+
+  oem_iana = ntohl(resp_hdr->manufacturer_id);
+  if (oem_iana != BCM_IANA) {
+    ncsi_log(LOG_ERR, "Error: bad ncsi oem manufacturer id 0x%x", oem_iana);
+    return -1;
+  }
+
+  if (resp_hdr->brcm_cmd_type != brcm_cmd_type) {
+    ncsi_log(LOG_ERR, "Error: bad ncsi brcm cmd 0x%x, expect 0x%x",
+          resp_hdr->brcm_cmd_type, brcm_cmd_type);
+    return -1;
+  }
+
+  return 0;
+}
+
+int ncsi_brcm_check_resp_len(NCSI_NL_RSP_T *nl_resp, uint16_t min_resp_size)
+{
+  NCSI_Brcm_Response_Hdr *resp_hdr = ncsi_get_brcm_resp(nl_resp);
+  uint16_t brcm_payload_len;
+
+  if (nl_resp->hdr.payload_length < min_resp_size) {
+    ncsi_log(LOG_ERR, "Error: ncsi response payload length %u too short for "
+             "brcm min size %u", nl_resp->hdr.payload_length, min_resp_size);
+    return -1;
+  }
+
+  brcm_payload_len = ntohs(resp_hdr->brcm_payload_len);
+  if (nl_resp->hdr.payload_length != sizeof(*resp_hdr) + brcm_payload_len) {
+    ncsi_log(LOG_ERR, "Error: ncsi payload len %u not match "
+             "brcm len (hdr %u + payload %u)",
+             nl_resp->hdr.payload_length, sizeof(*resp_hdr), brcm_payload_len);
+    return -1;
+  }
+
+  return 0;
+}
+
+int ncsi_brcm_check_resp(NCSI_NL_RSP_T *nl_resp, uint8_t brcm_cmd_type,
+                         uint16_t min_resp_size)
+{
+  if (ncsi_brcm_check_resp_type(nl_resp, brcm_cmd_type)) {
+    return -1;
+  }
+
+  if (ncsi_brcm_check_resp_len(nl_resp, min_resp_size)) {
+    return -1;
+  }
+
+  return 0;
+}
+
+void ncsi_brcm_print_resp_brcm_hdr(NCSI_NL_RSP_T *nl_resp)
+{
+  NCSI_Brcm_Response_Hdr *resp_hdr = ncsi_get_brcm_resp(nl_resp);
+  uint32_t oem_iana = ntohl(resp_hdr->manufacturer_id);
+
+  printf("IANA: %s(0x%x)\n",
+         (oem_iana == BCM_IANA) ? "Broadcom" : "Other", oem_iana);
+  printf("Brcm cmd: %s(0x%x)\n",
+         ncsi_brcm_cmd_type_to_name(resp_hdr->brcm_cmd_type),
+         resp_hdr->brcm_cmd_type);
+  printf("Brcm payload length: %u\n", ntohs(resp_hdr->brcm_payload_len));
+  printf("Brcm payload version: %u\n", resp_hdr->brcm_payload_ver);
+}
+
+void ncsi_brcm_print_resp(NCSI_NL_RSP_T *nl_resp)
+{
+  NCSI_Brcm_Response_Hdr *resp_hdr = ncsi_get_brcm_resp(nl_resp);
+
+  print_ncsi_completion_codes(nl_resp);
+  if (get_cmd_status(nl_resp) != RESP_COMMAND_COMPLETED)
+    return;
+
+  ncsi_brcm_print_resp_brcm_hdr(nl_resp);
+
+  switch (resp_hdr->brcm_cmd_type) {
+  case NCSI_BRCM_GET_DEBUG_DATA:
+    ncsi_brcm_print_get_debug_data(nl_resp);
+    break;
+  default:
+    print_ncsi_data(resp_hdr + 1, ntohs(resp_hdr->brcm_payload_len), 64,
+                    sizeof(CTRL_MSG_HDR_t) + sizeof(*resp_hdr));
+    break;
+  }
+}
+
+/*
+ * GetDebugData functions
+ */
+const char *ncsi_brcm_get_debug_type_to_name(int type)
+{
+  switch (type) {
+    case NCSI_BRCM_GET_DEBUG_DATA_TYPE_CORE_DUMP:
+      return "coredump";
+    case NCSI_BRCM_GET_DEBUG_DATA_TYPE_CRASH_DUMP:
+      return "crashdump";
+    default:
+      return "unknown";
+  }
+}
+
+int ncsi_brcm_check_get_debug_data(NCSI_NL_RSP_T *nl_resp, int debug_data_type,
+                                   bool is_first)
+{
+  NCSI_Brcm_Get_Debug_Data_Response *gdd_resp = ncsi_get_brcm_resp(nl_resp);
+  int data_len = nl_resp->hdr.payload_length - sizeof(*gdd_resp);
+
+  /* Check GetDebugData response data */
+  gdd_resp = ncsi_get_brcm_resp(nl_resp);
+  if (ntohs(gdd_resp->type) != debug_data_type) {
+    ncsi_log(LOG_ERR, "Error: bad GetDebugData type 0x%x, expect 0x%x",
+             ntohs(gdd_resp->type), debug_data_type);
+    return -1;
+  }
+
+
+  if (is_first) {
+    /* First response must have op of star not middle */
+    if (!(gdd_resp->op & NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_START) ||
+        (gdd_resp->op & NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_MIDDLE)) {
+      ncsi_log(LOG_ERR, "Error: bad GetDebugData Start response op 0x%x",
+               gdd_resp->op);
+      return -1;
+    }
+
+    /* First response must contain debug data length word */
+    if (data_len < sizeof(uint32_t)) {
+      ncsi_log(LOG_ERR, "Error: GetDebugData Start response data too short (%u)"
+               ,  data_len);
+      return -1;
+    }
+
+    /* Exclude debug data length */
+    data_len -= sizeof(uint32_t);
+
+  } else {
+      /* Next response must has op of middle or end not start */
+    if ((gdd_resp->op & NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_START) ||
+        !(gdd_resp->op & (NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_MIDDLE |
+                          NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_END))) {
+      ncsi_log(LOG_ERR, "Error: bad GetDebugData GetNext response op 0x%x",
+               gdd_resp->op);
+      return -1;
+    }
+  }
+
+  if (gdd_resp->op & NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_END) {
+    /* Last response must have CRC32 checksum word */
+    if (data_len < sizeof(uint32_t)) {
+      ncsi_log(LOG_ERR, "Error: GetDebugData End response data too short (%u)",
+               data_len);
+      return -1;
+    }
+
+    /* Exclude checksum */
+    data_len -= sizeof(uint32_t);
+  }
+
+  return 0;
+}
+
+void ncsi_brcm_print_get_debug_data(NCSI_NL_RSP_T *nl_resp)
+{
+  NCSI_Brcm_Get_Debug_Data_Response *gdd_resp = ncsi_get_brcm_resp(nl_resp);
+  int debug_data_len = ntohs(gdd_resp->header.brcm_payload_len)
+                        - NCSI_BRCM_RESP_STRUCT_PAYLOAD_SIZE(gdd_resp);
+
+  printf("Data length: %u\n", debug_data_len);
+  printf("Type: %s\n", ncsi_brcm_get_debug_type_to_name(ntohs(gdd_resp->type)));
+  printf("Op:");
+  if (gdd_resp->op & NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_START) {
+    printf(" start");
+  }
+  if (gdd_resp->op & NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_MIDDLE) {
+    printf(" middle");
+  }
+  if (gdd_resp->op & NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_END) {
+    printf(" end");
+  }
+  printf("\n");
+  printf("Next handle: 0x%x\n", ntohl(gdd_resp->next_data_handle));
+  printf("Debug data:\n");
+  print_ncsi_data(gdd_resp->debug_data, debug_data_len, 32 /* max print num */,
+                  sizeof(CTRL_MSG_HDR_t) + sizeof(*gdd_resp));
+}

--- a/common/recipes-lib/ncsi/files/ncsi-brcm.h
+++ b/common/recipes-lib/ncsi/files/ncsi-brcm.h
@@ -1,0 +1,115 @@
+/*
+ * ncsi-brcm.h
+ *
+ * Copyright 2020-present Facebook. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#ifndef _NCSI_BRCM_H_
+#define _NCSI_BRCM_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "ncsi.h"
+
+/*
+ * Broadcom OEM request and response header
+ */
+typedef struct {
+  uint32_t manufacturer_id;
+  uint8_t  brcm_payload_ver;
+  uint8_t  brcm_cmd_type;
+  uint16_t brcm_payload_len;
+  uint32_t reserved;
+} __attribute__((packed)) NCSI_Brcm_Request_Hdr;
+
+typedef struct {
+  uint16_t response_code;
+  uint16_t reason_code;
+  uint32_t manufacturer_id;
+  uint8_t  brcm_payload_ver;
+  uint8_t  brcm_cmd_type;
+  uint16_t brcm_payload_len;
+} __attribute__((packed)) NCSI_Brcm_Response_Hdr;
+
+/* Broadcom OEM payload version */
+#define NCSI_BRCM_PAYLOAD_VERSION       0
+
+/*
+ * Broadcom OEM command types
+ */
+#define NCSI_BRCM_GET_DEBUG_DATA        0x30
+
+/*
+ * GetDebugData
+ */
+typedef struct {
+  NCSI_Brcm_Request_Hdr   header;
+  uint32_t                data_handle;
+  uint8_t                 reserved1;
+  uint8_t                 op;
+  uint16_t                type;
+} __attribute__((packed)) NCSI_Brcm_Get_Debug_Data_Request;
+
+typedef struct {
+  NCSI_Brcm_Response_Hdr  header;
+  uint32_t                next_data_handle;
+  uint8_t                 reserved;
+  uint8_t                 op;
+  uint16_t                type;
+  uint8_t                 debug_data[0]; /* data of variable length */
+} __attribute__((packed)) NCSI_Brcm_Get_Debug_Data_Response;
+
+#define NCSI_BRCM_GET_DEBUG_DATA_TYPE_CORE_DUMP     0
+#define NCSI_BRCM_GET_DEBUG_DATA_TYPE_CRASH_DUMP    1
+
+#define NCSI_BRCM_GET_DEBUG_DATA_REQ_OP_MASK        0xf
+#define NCSI_BRCM_GET_DEBUG_DATA_REQ_OP_GET_NEXT    0
+#define NCSI_BRCM_GET_DEBUG_DATA_REQ_OP_START_XFER  1
+
+#define NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_MASK       0xf
+#define NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_START      0x1
+#define NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_MIDDLE     0x2
+#define NCSI_BRCM_GET_DEBUG_DATA_RESP_OP_END        0x4
+
+
+/* Broadcom OEM response structure payload size */
+#define NCSI_BRCM_RESP_STRUCT_PAYLOAD_SIZE(brcm_resp) \
+  (sizeof(*(brcm_resp)) - sizeof(NCSI_Brcm_Response_Hdr))
+
+const char *ncsi_brcm_cmd_type_to_name(uint8_t cmd);
+
+int ncsi_brcm_create_req_pkt(NCSI_NL_MSG_T *nl_msg, uint8_t ch, uint8_t cmd,
+                             uint16_t req_len, void *req);
+
+/* Get Broadcom OEM response from NC-SI response message */
+static inline void *ncsi_get_brcm_resp(NCSI_NL_RSP_T *nl_resp)
+{
+  return nl_resp->msg_payload;
+}
+
+int ncsi_brcm_check_resp_type(NCSI_NL_RSP_T *nl_resp, uint8_t brcm_cmd_type);
+int ncsi_brcm_check_resp_len(NCSI_NL_RSP_T *nl_resp, uint16_t min_resp_size);
+int ncsi_brcm_check_resp(NCSI_NL_RSP_T *nl_resp, uint8_t brcm_cmd_type,
+                         uint16_t min_resp_size);
+void ncsi_brcm_print_resp_brcm_hdr(NCSI_NL_RSP_T *nl_resp);
+void ncsi_brcm_print_resp(NCSI_NL_RSP_T *nl_resp);
+
+const char *ncsi_brcm_get_debug_type_to_name(int type);
+int ncsi_brcm_check_get_debug_data(NCSI_NL_RSP_T *nl_resp, int debug_data_type,
+                                   bool is_first);
+void ncsi_brcm_print_get_debug_data(NCSI_NL_RSP_T *nl_resp);
+
+#endif /* _NCSI_BRCM_H_ */

--- a/common/recipes-lib/ncsi/files/ncsi.c
+++ b/common/recipes-lib/ncsi/files/ncsi.c
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <syslog.h>
 #include <pthread.h>
 #include <string.h>
@@ -56,6 +57,7 @@ const char *ncsi_reason_string[NUM_NCSI_REASON_CODE] = {
   "CHANNEL_NOT_RDY",
   "PKG_NOT_RDY",
   "INVALID_PAYLOAD_LEN",
+  "INFO_NOT_AVAIL",
   "UNKNOWN_CMD_TYPE",
 };
 
@@ -110,6 +112,38 @@ const char *link_speed_string[] = {
   "2.5Gbps",
   "reserved",
 };
+
+// NC-SI lib logging function.
+// If the logging method is printf, it will add '\n' for the message.
+void (*ncsi_log)(int priority, const char *format, ...)
+          __attribute__ ((__format__ (__printf__, 2, 3))) = syslog;
+
+// NC-SI printf
+// priority - syslog priority, e.g. LOG_ERR, LOG_WARINING, ...
+static void ncsi_printf(int priority, const char *format, ...)
+{
+  va_list ap;
+
+  va_start(ap, format);
+  vprintf(format, ap);
+  va_end(ap);
+  printf("\n");
+}
+
+// Configure NC-SI lib logging
+void ncsi_config_log(int log_method)
+{
+  switch (log_method) {
+    case NCSI_LOG_METHOD_SYSLOG:
+      ncsi_log = syslog;
+      break;
+    case NCSI_LOG_METHOD_PRINTF:
+      ncsi_log = ncsi_printf;
+      break;
+    default:
+      break;
+  }
+}
 
 // reload kernel NC-SI driver and trigger NC-SI interface initialization
 int
@@ -297,6 +331,25 @@ ncsi_cc_reson_name(int cc_reason)
   }
 }
 
+// Print up to print_num of data bytes
+// If print_num is 0 or negative, print all data.
+// print_offset is the starting offset printed on each line.
+void print_ncsi_data(void *data, int size, int print_num, int print_offset)
+{
+  int n = (print_num <= 0 || size <= print_num) ? size : print_num;
+  int i;
+
+  for (i = 0; i < n; ++i) {
+  		if (i % 4 == 0)
+  			printf("\n%02d: ", print_offset + i);
+      printf("0x%02x ", ((uint8_t *)data)[i]);
+  }
+  printf("\n");
+
+  if (n < size)
+    printf("...\n");
+}
+
 void print_ncsi_completion_codes(NCSI_NL_RSP_T *rcv_buf)
 {
   uint8_t *pbuf = rcv_buf->msg_payload;
@@ -327,7 +380,6 @@ get_cmd_status(NCSI_NL_RSP_T *rcv_buf)
 void
 print_ncsi_resp(NCSI_NL_RSP_T *rcv_buf)
 {
-  int i = 0;
   int cmd = rcv_buf->hdr.cmd;
 
   print_ncsi_completion_codes(rcv_buf);
@@ -357,13 +409,8 @@ print_ncsi_resp(NCSI_NL_RSP_T *rcv_buf)
     break;
   default:
     printf("Payload length = %d\n",rcv_buf->hdr.payload_length);
-    for (i = 4; i < rcv_buf->hdr.payload_length; ++i) {
-  		if (i && !(i%4))
-  			printf("\n%d: ", 16+i);
-      printf("0x%02x ", rcv_buf->msg_payload[i]);
-    }
-    printf("\n");
-
+    print_ncsi_data(&rcv_buf->msg_payload[4], rcv_buf->hdr.payload_length - 4,
+                    0 /* print all */, sizeof(CTRL_MSG_HDR_t) + 4 /* print off */);
   }
 
   return;
@@ -652,7 +699,7 @@ handle_get_version_id(NCSI_Response_Packet *resp)
   }
 
   lseek(fd, (long)&((Get_Version_ID_Response *)0)->fw_ver, SEEK_SET);
-  int version_length = read(fd, nic_fw_ver, sizeof(nic_fw_ver)); 
+  int version_length = read(fd, nic_fw_ver, sizeof(nic_fw_ver));
   if (version_length != 0 && version_length != sizeof(nic_fw_ver)) {
     close(fd);
     return -1;

--- a/common/recipes-lib/ncsi/libncsi_0.1.bb
+++ b/common/recipes-lib/ncsi/libncsi_0.1.bb
@@ -12,6 +12,8 @@ SRC_URI = "file://Makefile \
            file://ncsi.h \
            file://aen.c \
            file://aen.h \
+           file://ncsi-brcm.c \
+           file://ncsi-brcm.h \
           "
 
 S = "${WORKDIR}"
@@ -26,6 +28,7 @@ do_install() {
     install -d ${D}${includedir}/openbmc
     install -m 0644 ncsi.h ${D}${includedir}/openbmc/ncsi.h
     install -m 0644 aen.h ${D}${includedir}/openbmc/aen.h
+    install -m 0644 ncsi-brcm.h ${D}${includedir}/openbmc/ncsi-brcm.h
 }
 
 DEPENDS += "libkv"


### PR DESCRIPTION
libncsi and ncsi-util changes for supporting Broadcom OEM GetDebugData, which retrieves NIC's debug data from BMC.