### PR TITLE
Add extra check for data partition mount state in galaxy100

### DIFF
--- a/tools/flashy/checks_and_remediations/common/20_unmount_data_partition.go
+++ b/tools/flashy/checks_and_remediations/common/20_unmount_data_partition.go
@@ -26,7 +26,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/logger"
 	"github.com/facebook/openbmc/tools/flashy/lib/step"
 	"github.com/facebook/openbmc/tools/flashy/lib/utils"
@@ -47,7 +46,7 @@ var mount = syscall.Mount
 // may be corrupted by the preexisting data0 partition.
 // Also, should there be a need to format data0, this step is necessary.
 func unmountDataPartition(stepParams step.StepParams) step.StepExitError {
-	dataMounted, err := isDataPartitionMounted()
+	dataMounted, err := utils.IsDataPartitionMounted()
 	if err != nil {
 		return step.ExitSafeToReboot{
 			errors.Errorf("Unable to determine whether /mnt/data is mounted: %v",
@@ -93,21 +92,6 @@ func unmountDataPartition(stepParams step.StepParams) step.StepExitError {
 	}
 
 	return nil
-}
-
-var isDataPartitionMounted = func() (bool, error) {
-	procMountsDat, err := fileutils.ReadFile(procMountsPath)
-	if err != nil {
-		return false, errors.Errorf("Cannot read /proc/mounts: %v", err)
-	}
-
-	regEx := `(?m)^[^ ]+ /mnt/data [^ ]+ [^ ]+ [0-9]+ [0-9]+$`
-	regExMap, err := utils.GetAllRegexSubexpMap(regEx, string(procMountsDat))
-	if err != nil {
-		return false, errors.Errorf("regex error: %v", err)
-	}
-
-	return len(regExMap) != 0, nil
 }
 
 // runDataPartitionUnmountProcess attempts (up to 10 times) to unmount /mnt/data

--- a/tools/flashy/checks_and_remediations/common/20_unmount_data_partition.go
+++ b/tools/flashy/checks_and_remediations/common/20_unmount_data_partition.go
@@ -32,8 +32,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const procMountsPath = "/proc/mounts"
-
 func init() {
 	step.RegisterStep(unmountDataPartition)
 }

--- a/tools/flashy/lib/utils/system.go
+++ b/tools/flashy/lib/utils/system.go
@@ -46,6 +46,7 @@ type MemInfo struct {
 
 const ProcMtdFilePath = "/proc/mtd"
 const etcIssueFilePath = "/etc/issue"
+const procMountsPath = "/proc/mounts"
 
 // other flashers + the "flashy" binary
 var otherFlasherBaseNames = []string{

--- a/tools/flashy/lib/utils/system.go
+++ b/tools/flashy/lib/utils/system.go
@@ -377,3 +377,19 @@ var GetMTDMapFromSpecifier = func(deviceSpecifier string) (map[string]string, er
 	}
 	return mtdMap, nil
 }
+
+// IsDataPartitionMounted checks if /mnt/data is mounted
+var IsDataPartitionMounted = func() (bool, error) {
+	procMountsDat, err := fileutils.ReadFile(procMountsPath)
+	if err != nil {
+		return false, errors.Errorf("Cannot read /proc/mounts: %v", err)
+	}
+
+	regEx := `(?m)^[^ ]+ /mnt/data [^ ]+ [^ ]+ [0-9]+ [0-9]+$`
+	regExMap, err := GetAllRegexSubexpMap(regEx, string(procMountsDat))
+	if err != nil {
+		return false, errors.Errorf("regex error: %v", err)
+	}
+
+	return len(regExMap) != 0, nil
+}

--- a/tools/flashy/lib/utils/system_test.go
+++ b/tools/flashy/lib/utils/system_test.go
@@ -923,7 +923,7 @@ func TestIsDataPartitionMounted(t *testing.T) {
 				return []byte(tc.procMountContents), tc.procMountReadErr
 			}
 
-			got, err := isDataPartitionMounted()
+			got, err := IsDataPartitionMounted()
 			tests.CompareTestErrors(tc.wantErr, err, t)
 			if tc.want != got {
 				t.Errorf("want '%v' got '%v'", tc.want, got)


### PR DESCRIPTION
The unmount data partition remediation may fall back to remounting RO. In that case formatting it on galaxy100 devices with Diag folders will cause the device to reboot.

Make sure the data partition is unmounted before proceeding.