### PR TITLE
Add Docker HUB auth into CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
     lint:
         docker:
             - image: ubuntu:focal
+              auth:
+                  username: $DOCKERHUB_USERNAME
+                  password: $DOCKERHUB_TOKEN
         resource_class: small
         steps:
             - run:
@@ -25,6 +28,9 @@ jobs:
     setup:
         docker:
             - image: crops/poky:latest
+              auth:
+                  username: $DOCKERHUB_USERNAME
+                  password: $DOCKERHUB_TOKEN
         resource_class: small
         working_directory: /tmp/job/project
         steps:
@@ -47,6 +53,9 @@ jobs:
                   MACHINE: << parameters.machine >>
                   CACHE_DIR: /tmp/job/sstate-cache
                   CACHE_URI: https://fb-openbmc-sstate.s3.us-east-2.amazonaws.com
+              auth:
+                  username: $DOCKERHUB_USERNAME
+                  password: $DOCKERHUB_TOKEN
         resource_class: xlarge
         working_directory: /tmp/job/project
         steps:
@@ -68,9 +77,12 @@ workflows:
     version: 2
     everything:
         jobs:
-            - lint
-            - setup
+            - lint:
+                context: DOCKERHUB_TOKEN
+            - setup:
+                context: DOCKERHUB_TOKEN
             - build:
+                context: DOCKERHUB_TOKEN
                 requires:
                     - setup
                 matrix:


### PR DESCRIPTION
Starting November 1, Docker Hub expects users to log in for pulling images. After this date, some anonymous pulls will be rate-limited by IP address.

Adding authentication to avoid potential issues that which result from the above.