### PR TITLE
flashy: Add bounds check when accessing slices

### DIFF
--- a/tools/flashy/lib/flash/flashcp/flashcp.go
+++ b/tools/flashy/lib/flash/flashcp/flashcp.go
@@ -299,6 +299,10 @@ var flashImage = func(
 ) error {
 	log.Printf("Flashing image '%v' on to flash device '%v'", imFile.name, deviceFile.Name())
 
+	if roOffset > uint32(len(imFile.data)) {
+		return errors.Errorf("Failed to flash image: roOffset (%vB) larger than image file (%vB)",
+			roOffset, len(imFile.data))
+	}
 	activeImageData := imFile.data[roOffset:]
 
 	// use Pwrite, WriteAt may call Pwrite multiple times under the hood

--- a/tools/flashy/lib/flash/flashcp/flashcp.go
+++ b/tools/flashy/lib/flash/flashcp/flashcp.go
@@ -346,12 +346,16 @@ var verifyFlash = func(
 	}
 	defer fileutils.Munmap(flashData)
 
+	if roOffset > imageSize {
+		return errors.Errorf("Failed to verify image: roOffset (%vB) larger than image file (%vB)",
+			roOffset, imageSize)
+	}
 	activeImageData := imFile.data[roOffset:]
-	activeFlashData := flashData[roOffset:]
+	activeFlashData := flashData[roOffset:] // this bound is safe due to mmap-ing imageSize
 
 	if !bytes.Equal(activeFlashData, activeImageData) {
-		errMsg := fmt.Sprintf("Verification failed: flash and image data mismatch.")
-		log.Printf(errMsg)
+		errMsg := "Verification failed: flash and image data mismatch."
+		log.Print(errMsg)
 		return errors.Errorf("%v", errMsg)
 	}
 

--- a/tools/flashy/lib/flash/flashcp/flashcp_test.go
+++ b/tools/flashy/lib/flash/flashcp/flashcp_test.go
@@ -588,6 +588,12 @@ func TestFlashImage(t *testing.T) {
 			writeErr: nil,
 			want:     nil,
 		},
+		{
+			name:     "roOffset too large",
+			roOffset: 8,
+			writeErr: nil,
+			want:     errors.Errorf("Failed to flash image: roOffset (8B) larger than image file (6B)"),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tools/flashy/lib/flash/flashcp/flashcp_test.go
+++ b/tools/flashy/lib/flash/flashcp/flashcp_test.go
@@ -694,6 +694,14 @@ func TestVerifyFlash(t *testing.T) {
 			mmapErr:        nil,
 			want:           nil,
 		},
+		{
+			name:           "roOffset too large",
+			roOffset:       8,
+			deviceFileName: "/dev/mtd42",
+			deviceData:     imData,
+			mmapErr:        nil,
+			want:           errors.Errorf("Failed to verify image: roOffset (8B) larger than image file (6B)"),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
# Summary

Add bounds check for three functions:
- flashImage
- verifyFlash
- getChecksum

Out of bounds accesses in golang trigger panics and hence bad error messages, so prefer to return (and handle) errors instead.

Another diff with overflow checks will be done soon!

## Test plan
Unit tests added: `go test ./...`