### PR TITLE
flashy: Use safe addition to return errors when operands overflow

### DIFF
--- a/tools/flashy/lib/flash/flashcp/flashcp_test.go
+++ b/tools/flashy/lib/flash/flashcp/flashcp_test.go
@@ -21,6 +21,7 @@ package flashcp
 
 import (
 	"bytes"
+	"math"
 	"testing"
 	"unsafe"
 
@@ -513,6 +514,15 @@ func TestEraseFlashDevice(t *testing.T) {
 			wantEraseLen:   6,
 			ioctlErr:       nil,
 			want:           nil,
+		},
+		{
+			name:           "overflowed",
+			roOffset:       0,
+			mtdErasesize:   math.MaxUint32 - 4,
+			wantEraseStart: 0,
+			wantEraseLen:   8,
+			ioctlErr:       nil,
+			want:           errors.Errorf("Failed to get erase length: Unsigned integer overflow for (6+4294967291)"),
 		},
 	}
 

--- a/tools/flashy/lib/utils/helper.go
+++ b/tools/flashy/lib/utils/helper.go
@@ -244,11 +244,15 @@ func SafeAppendString(a, b []string) []string {
 // GetWord gets a 4 byte uint32 from a byte slice 'data' from offset to offset+4.
 // It returns an error if the offset is out of range.
 func GetWord(data []byte, offset uint32) (uint32, error) {
-	if offset+4 > uint32(len(data)) {
+	endOffset, err := AddU32(offset, 4)
+	if err != nil {
+		return 0, errors.Errorf("Failed to get end of offset: %v", err)
+	}
+	if endOffset > uint32(len(data)) {
 		return 0, errors.Errorf("Required offset %v out of range of data size %v",
 			offset, len(data))
 	}
-	val := binary.BigEndian.Uint32(data[offset : offset+4])
+	val := binary.BigEndian.Uint32(data[offset:endOffset])
 	return val, nil
 }
 
@@ -257,7 +261,11 @@ func GetWord(data []byte, offset uint32) (uint32, error) {
 // Warning: make an explicit copy if the original array is required again after
 // SetWord.
 func SetWord(data []byte, word, offset uint32) ([]byte, error) {
-	if offset+4 > uint32(len(data)) {
+	endOffset, err := AddU32(offset, 4)
+	if err != nil {
+		return nil, errors.Errorf("Failed to get end of offset: %v", err)
+	}
+	if endOffset > uint32(len(data)) {
 		return nil, errors.Errorf("Required offset %v out of range of data size %v",
 			offset, len(data))
 	}

--- a/tools/flashy/lib/utils/helper_test.go
+++ b/tools/flashy/lib/utils/helper_test.go
@@ -21,6 +21,7 @@ package utils
 
 import (
 	"bytes"
+	"math"
 	"reflect"
 	"sort"
 	"testing"
@@ -491,6 +492,13 @@ func TestGetWord(t *testing.T) {
 			wantErr: errors.Errorf("Required offset %v out of range of data size %v",
 				2, 4),
 		},
+		{
+			name:    "overflowed",
+			data:    []byte{0x01, 0x02, 0x03, 0x04},
+			offset:  math.MaxUint32 - 3,
+			want:    0,
+			wantErr: errors.Errorf("Failed to get end of offset: Unsigned integer overflow for (4294967292+4)"),
+		},
 	}
 	for _, tc := range cases {
 		got, err := GetWord(tc.data, tc.offset)
@@ -526,6 +534,14 @@ func TestSetWord(t *testing.T) {
 			want:   nil,
 			wantErr: errors.Errorf("Required offset %v out of range of data size %v",
 				2, 4),
+		},
+		{
+			name:    "overflowed",
+			data:    []byte{0x01, 0x02, 0x03, 0x04},
+			word:    0x12345678,
+			offset:  math.MaxUint32 - 3,
+			want:    nil,
+			wantErr: errors.Errorf("Failed to get end of offset: Unsigned integer overflow for (4294967292+4)"),
 		},
 	}
 	for _, tc := range cases {

--- a/tools/flashy/lib/utils/math.go
+++ b/tools/flashy/lib/utils/math.go
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2021-present Facebook. All Rights Reserved.
+ *
+ * This program file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in a file named COPYING; if not, write to the
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+package utils
+
+import (
+	"math"
+
+	"github.com/pkg/errors"
+)
+
+// AddU32 returns an error if the result overflowed Uint32 bounds.
+func AddU32(x, y uint32) (uint32, error) {
+	if x > math.MaxUint32-y {
+		return 0, errors.Errorf("Unsigned integer overflow for (%v+%v)", x, y)
+	}
+	return x + y, nil
+}

--- a/tools/flashy/lib/utils/math_test.go
+++ b/tools/flashy/lib/utils/math_test.go
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2021-present Facebook. All Rights Reserved.
+ *
+ * This program file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in a file named COPYING; if not, write to the
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+package utils
+
+import (
+	"math"
+	"testing"
+
+	"github.com/facebook/openbmc/tools/flashy/tests"
+	"github.com/pkg/errors"
+)
+
+func TestAddU32(t *testing.T) {
+	cases := []struct {
+		name    string
+		x       uint32
+		y       uint32
+		want    uint32
+		wantErr error
+	}{
+		{
+			name:    "OK",
+			x:       32,
+			y:       42,
+			want:    32 + 42,
+			wantErr: nil,
+		},
+		{
+			name:    "Overflowed",
+			x:       math.MaxUint32 - 1,
+			y:       2,
+			want:    0,
+			wantErr: errors.Errorf("Unsigned integer overflow for (4294967294+2)"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := AddU32(tc.x, tc.y)
+			if err != nil {
+				tests.CompareTestErrors(tc.wantErr, err, t)
+			} else if tc.want != got {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
+		})
+	}
+}

--- a/tools/flashy/lib/utils/vboot.go
+++ b/tools/flashy/lib/utils/vboot.go
@@ -147,7 +147,11 @@ var GetVbs = func() (Vbs, error) {
 	}
 
 	dataOffset := fileutils.GetPageOffsettedOffset(AST_SRAM_VBS_BASE)
-	vbsData := pageData[dataOffset : dataOffset+AST_SRAM_VBS_SIZE]
+	vbsEndOffset, err := AddU32(dataOffset, AST_SRAM_VBS_SIZE)
+	if err != nil {
+		return vbs, errors.Errorf("VBS end offset overflowed: %v", err)
+	}
+	vbsData := pageData[dataOffset:vbsEndOffset]
 
 	return decodeVbs(vbsData)
 }

--- a/tools/flashy/lib/validate/partition/p_fit.go
+++ b/tools/flashy/lib/validate/partition/p_fit.go
@@ -24,6 +24,7 @@ import (
 	"crypto/sha256"
 	"log"
 
+	"github.com/facebook/openbmc/tools/flashy/lib/utils"
 	"github.com/pkg/errors"
 	"github.com/u-root/u-root/pkg/dt"
 )
@@ -205,13 +206,16 @@ func (p *FitPartition) getDataFromImageNodeViaDataLink(imageNode *dt.Node) ([]by
 		return nil, err
 	}
 
-	endOffset := dataPos + dataSize
+	endOffset, err := utils.AddU32(dataPos, dataSize)
+	if err != nil {
+		return nil, errors.Errorf("End offset overflowed: %v", err)
+	}
 	if endOffset > p.GetSize() {
 		return nil, errors.Errorf("End offset required (%v) by 'data-size' (%v) and 'data-position' (%v) "+
 			"too large for partition size (%v)", endOffset, dataSize, dataPos, p.GetSize())
 	}
 
-	return p.Data[dataPos : dataPos+dataSize], nil
+	return p.Data[dataPos:endOffset], nil
 }
 
 // given the image node, get the sha256 checksum.

--- a/tools/flashy/lib/validate/partition/p_fit_test.go
+++ b/tools/flashy/lib/validate/partition/p_fit_test.go
@@ -698,6 +698,24 @@ func TestGetDataFromImageNodeViaDataLink(t *testing.T) {
 			wantErr: errors.Errorf("End offset required (67108868) by 'data-size' " +
 				"(67108864) and 'data-position' (4) too large for partition size (1024)"),
 		},
+		{
+			name: "end offset overflowed",
+			imageNode: &dt.Node{
+				Name: "imageNode1",
+				Properties: []dt.Property{
+					{
+						Name:  "data-size",
+						Value: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+					},
+					{
+						Name:  "data-position",
+						Value: []byte{0x00, 0x00, 0x00, 0x04},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: errors.Errorf("End offset overflowed: Unsigned integer overflow for (4+4294967295)"),
+		},
 	}
 
 	for _, tc := range cases {

--- a/tools/flashy/lib/validate/partition/validate.go
+++ b/tools/flashy/lib/validate/partition/validate.go
@@ -22,6 +22,7 @@ package partition
 import (
 	"log"
 
+	"github.com/facebook/openbmc/tools/flashy/lib/utils"
 	"github.com/pkg/errors"
 )
 
@@ -83,7 +84,10 @@ var getAllPartitionsFromPartitionConfigs = func(
 		// but that would require operating on a new copy of the image in memory.
 		// Golang mmap unfortunately doesn't expose the addr argument to allow
 		// fixed mapping (we could map a 23MB image file over a 32MB /dev/zero file)
-		pOffsetEnd := pInfo.Size + pInfo.Offset
+		pOffsetEnd, err := utils.AddU32(pInfo.Size, pInfo.Offset)
+		if err != nil {
+			return nil, errors.Errorf("Unable to get offset end: %v", err)
+		}
 		if uint32(len(data)) < pOffsetEnd {
 			actualPartitionSize := uint32(len(data)) - pInfo.Offset
 			pInfo.Size = actualPartitionSize

--- a/tools/flashy/lib/validate/partition/validate_test.go
+++ b/tools/flashy/lib/validate/partition/validate_test.go
@@ -21,6 +21,7 @@ package partition
 
 import (
 	"crypto/rand"
+	"math"
 	"reflect"
 	"testing"
 
@@ -246,6 +247,19 @@ func TestGetAllPartitionsFromPartitionConfigs(t *testing.T) {
 			want: nil,
 			wantErr: errors.Errorf("Wanted start offset (%v) larger than image file size (%v)",
 				20*1024, 4*1024),
+		},
+		{
+			name: "end offset too large",
+			partitionConfigs: []PartitionConfigInfo{
+				{
+					Name:   "foobar",
+					Offset: 1024,
+					Size:   math.MaxUint32 - 1000,
+					Type:   mockConfigTypeFoo,
+				},
+			},
+			want:    nil,
+			wantErr: errors.Errorf("Unable to get offset end: Unsigned integer overflow for (4294966295+1024)"),
 		},
 	}
 	// compare two partitions slices


### PR DESCRIPTION
# Summary

As title--uint32 addition wraps around and may cause bugs to go unnoticed. Use a safe addition function to facilitate addition.

No functional changes are made

# Test plan
Unit tests added (`go test ./...`)