### PR TITLE
flashy: Refactor regex capture groups to use constants to reduce mistakes

### DIFF
--- a/tools/flashy/lib/flash/flashutils/devices/mtd.go
+++ b/tools/flashy/lib/flash/flashutils/devices/mtd.go
@@ -109,7 +109,10 @@ func (m *MemoryTechnologyDevice) Validate() error {
 // from the /dev/mtd[0-9]+ file path.
 // /dev/mtd5 cannot be mmap-ed, but /dev/mtdblock5 can.
 var GetMTDBlockFilePath = func(filepath string) (string, error) {
-	regEx := `^(?P<devmtdpath>/dev/mtd)(?P<mtdnum>[0-9]+)$`
+	const rDevmtdpath = "devmtdpath"
+	const rMtdnum = "mtdnum"
+
+	regEx := fmt.Sprintf(`^(?P<%v>/dev/mtd)(?P<%v>[0-9]+)$`, rDevmtdpath, rMtdnum)
 
 	mtdPathMap, err := utils.GetRegexSubexpMap(regEx, filepath)
 	if err != nil {
@@ -119,7 +122,7 @@ var GetMTDBlockFilePath = func(filepath string) (string, error) {
 
 	return fmt.Sprintf(
 		"%vblock%v",
-		mtdPathMap["devmtdpath"],
-		mtdPathMap["mtdnum"],
+		mtdPathMap[rDevmtdpath],
+		mtdPathMap[rMtdnum],
 	), nil
 }

--- a/tools/flashy/lib/flash/flashutils/flashutils.go
+++ b/tools/flashy/lib/flash/flashutils/flashutils.go
@@ -35,7 +35,10 @@ import (
 // TODO:- e.g. “pfr:primary” -> type=”pfr” specifier=”primary”
 // TODO:- e.g. “file:/dev/sda” -> type=”file” specifier=”/dev/sda”
 var parseDeviceID = func(deviceID string) (string, string, error) {
-	regEx := `^(?P<type>[a-z]+):(?P<specifier>.+)$`
+	const rType = "type"
+	const rSpecifier = "specifier"
+
+	regEx := fmt.Sprintf(`^(?P<%v>[a-z]+):(?P<%v>.+)$`, rType, rSpecifier)
 
 	flashDeviceMap, err := utils.GetRegexSubexpMap(regEx, deviceID)
 	if err != nil {
@@ -43,7 +46,7 @@ var parseDeviceID = func(deviceID string) (string, string, error) {
 			deviceID, err)
 	}
 
-	return flashDeviceMap["type"], flashDeviceMap["specifier"], nil
+	return flashDeviceMap[rType], flashDeviceMap[rSpecifier], nil
 }
 
 // GetFlashDevice returns the FlashDevice given the device ID.

--- a/tools/flashy/lib/utils/system.go
+++ b/tools/flashy/lib/utils/system.go
@@ -275,7 +275,8 @@ var SystemdAvailable = func() (bool, error) {
 // WARNING: There is no guarantee that /etc/issue is well-formed
 // in old images.
 var GetOpenBMCVersionFromIssueFile = func() (string, error) {
-	const etcIssueVersionRegEx = `^OpenBMC Release (?P<version>[^\s]+)`
+	const rVersion = "version"
+	etcIssueVersionRegEx := fmt.Sprintf(`^OpenBMC Release (?P<%v>[^\s]+)`, rVersion)
 
 	etcIssueBuf, err := fileutils.ReadFile(etcIssueFilePath)
 	if err != nil {
@@ -293,7 +294,7 @@ var GetOpenBMCVersionFromIssueFile = func() (string, error) {
 				etcIssueFilePath, err)
 	}
 
-	version := etcIssueMap["version"]
+	version := etcIssueMap[rVersion]
 	return version, nil
 }
 
@@ -443,7 +444,7 @@ func tryPetWatchdog() bool {
 // - When /dev/watchdog is busy because it's held open by healthd, the delay
 //   here will hopefully allow healthd's watchdog thread to get some CPU
 //   time.
-//   
+//
 // - When /dev/watchdog it NOT busy because healthd is not running and there
 //   are no concurrent instances of wdtcli, the watchdog timeout will be
 //   extended and the watchdog petted.
@@ -451,7 +452,7 @@ var PetWatchdog = func() {
 	for i := 0; i < 10; i++ {
 		if tryPetWatchdog() {
 			log.Printf("Watchdog petted")
-			return;
+			return
 		}
 		time.Sleep(1 * time.Second)
 	}


### PR DESCRIPTION
# Summary

As title, use string constants for regex capture group names.

There is a remaining `GetMTDMapFromSpecifier` function still using string literals -- this function will be refactored in another diff and hence is not changed here.

## Test plan
Unit tests pass (`go test ./...`)

