### PR TITLE
flashy: Refactor GetMtdMapFromSpecific into GetMTDInfoFromSpecifier

### DIFF
--- a/tools/flashy/checks_and_remediations/yamp/00_erase_data_partition.go
+++ b/tools/flashy/checks_and_remediations/yamp/00_erase_data_partition.go
@@ -42,13 +42,13 @@ func eraseDataPartition(stepParams step.StepParams) step.StepExitError {
 		return nil
 	}
 
-	mtdMap, err := utils.GetMTDMapFromSpecifier("data0")
+	mtdInfo, err := utils.GetMTDInfoFromSpecifier("data0")
 	if err != nil {
-		log.Printf("Skipping this step: unable to get MTD map: %v", err)
+		log.Printf("Skipping this step: unable to get MTD info: %v", err)
 		return nil
 	}
 
-	if mtdMap["erasesize"] != "00010000" {
+	if mtdInfo.Erasesize != 0x00010000 {
 		log.Printf("Skipping this step: erasesize unchanged")
 		return nil
 	}

--- a/tools/flashy/checks_and_remediations/yamp/00_erase_data_partition_test.go
+++ b/tools/flashy/checks_and_remediations/yamp/00_erase_data_partition_test.go
@@ -47,12 +47,12 @@ func TestEraseDataPartition(t *testing.T) {
 	getFlashDeviceOrig := flashutils.GetFlashDevice
 	isDataPartitionMountedOrig := utils.IsDataPartitionMounted
 	runCommandOrig := utils.RunCommand
-	getMTDMapFromSpecifierOrig := utils.GetMTDMapFromSpecifier
+	getMTDInfoFromSpecifierOrig := utils.GetMTDInfoFromSpecifier
 	defer func() {
 		flashutils.GetFlashDevice = getFlashDeviceOrig
 		utils.IsDataPartitionMounted = isDataPartitionMountedOrig
 		utils.RunCommand = runCommandOrig
-		utils.GetMTDMapFromSpecifier = getMTDMapFromSpecifierOrig
+		utils.GetMTDInfoFromSpecifier = getMTDInfoFromSpecifierOrig
 	}()
 
 	flashDevice := &mockFlashDevice{}
@@ -60,7 +60,7 @@ func TestEraseDataPartition(t *testing.T) {
 	cases := []struct {
 		name              string
 		getFlashDeviceErr error
-		eraseSize         string
+		eraseSize         uint32
 		dataPartMounted   bool
 		dataPartErr       error
 		wantCmds          []string
@@ -70,17 +70,17 @@ func TestEraseDataPartition(t *testing.T) {
 		{
 			name:              "found and erased",
 			getFlashDeviceErr: nil,
-			eraseSize: 	 "00010000",
-			dataPartMounted: false,
-			dataPartErr:     nil,
-			wantCmds:        []string{"flash_eraseall -j /dev/mock"},
-			cmdErr:          nil,
-			want:            nil,
+			eraseSize:         0x00010000,
+			dataPartMounted:   false,
+			dataPartErr:       nil,
+			wantCmds:          []string{"flash_eraseall -j /dev/mock"},
+			cmdErr:            nil,
+			want:              nil,
 		},
 		{
 			name:              "No 'data0' partition found",
 			getFlashDeviceErr: errors.Errorf("not found"),
-			eraseSize:         "00001000",
+			eraseSize:         0x00001000,
 			dataPartMounted:   false,
 			dataPartErr:       nil,
 			wantCmds:          []string{},
@@ -90,7 +90,7 @@ func TestEraseDataPartition(t *testing.T) {
 		{
 			name:              "No Diag paths found",
 			getFlashDeviceErr: nil,
-			eraseSize:         "00001000",
+			eraseSize:         0x00001000,
 			dataPartMounted:   false,
 			dataPartErr:       nil,
 			wantCmds:          []string{},
@@ -100,11 +100,11 @@ func TestEraseDataPartition(t *testing.T) {
 		{
 			name:              "flash_eraseall failed",
 			getFlashDeviceErr: nil,
-			eraseSize:         "00010000",
-			dataPartMounted: false,
-			dataPartErr:     nil,
-			wantCmds:        []string{"flash_eraseall -j /dev/mock"},
-			cmdErr:          errors.Errorf("flash_eraseall failed"),
+			eraseSize:         0x00010000,
+			dataPartMounted:   false,
+			dataPartErr:       nil,
+			wantCmds:          []string{"flash_eraseall -j /dev/mock"},
+			cmdErr:            errors.Errorf("flash_eraseall failed"),
 			want: step.ExitSafeToReboot{
 				errors.Errorf("Failed to erase data0 partition: flash_eraseall failed"),
 			},
@@ -112,11 +112,11 @@ func TestEraseDataPartition(t *testing.T) {
 		{
 			name:              "error checking /mnt/data mount status",
 			getFlashDeviceErr: nil,
-			eraseSize:         "00010000",
-			dataPartMounted: false,
-			dataPartErr:     errors.Errorf("check failed"),
-			wantCmds:        []string{},
-			cmdErr:          nil,
+			eraseSize:         0x00010000,
+			dataPartMounted:   false,
+			dataPartErr:       errors.Errorf("check failed"),
+			wantCmds:          []string{},
+			cmdErr:            nil,
 			want: step.ExitSafeToReboot{
 				errors.Errorf("Failed to check if /mnt/data is mounted: check failed"),
 			},
@@ -124,11 +124,11 @@ func TestEraseDataPartition(t *testing.T) {
 		{
 			name:              "/mnt/data still mounted (RO, possibly)",
 			getFlashDeviceErr: nil,
-			eraseSize:         "00010000",
-			dataPartMounted: true,
-			dataPartErr:     nil,
-			wantCmds:        []string{},
-			cmdErr:          nil,
+			eraseSize:         0x00010000,
+			dataPartMounted:   true,
+			dataPartErr:       nil,
+			wantCmds:          []string{},
+			cmdErr:            nil,
 			want: step.ExitSafeToReboot{
 				errors.Errorf("/mnt/data is still mounted, this may mean that the " +
 					"unmount data partition step fell back to remounting RO. This current step " +
@@ -146,10 +146,10 @@ func TestEraseDataPartition(t *testing.T) {
 				}
 				return flashDevice, tc.getFlashDeviceErr
 			}
-			utils.GetMTDMapFromSpecifier = func(deviceID string) (map[string]string, error) {
-				m := make(map[string]string)
-				m["erasesize"] = tc.eraseSize
-				return m, nil
+			utils.GetMTDInfoFromSpecifier = func(deviceSpecifier string) (utils.MtdInfo, error) {
+				return utils.MtdInfo{
+					Erasesize: tc.eraseSize,
+				}, nil
 			}
 			utils.RunCommand = func(cmdArr []string, timeout time.Duration) (int, error, string, string) {
 				gotCmds = append(gotCmds, strings.Join(cmdArr, " "))

--- a/tools/flashy/lib/flash/flashutils/devices/mtd.go
+++ b/tools/flashy/lib/flash/flashutils/devices/mtd.go
@@ -22,7 +22,6 @@ package devices
 import (
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"syscall"
 
 	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
@@ -36,13 +35,12 @@ func init() {
 }
 
 func getMTD(deviceSpecifier string) (FlashDevice, error) {
-	mtdMap, err := utils.GetMTDMapFromSpecifier(deviceSpecifier)
+	mtdInfo, err := utils.GetMTDInfoFromSpecifier(deviceSpecifier)
 	if err != nil {
 		return nil, err
 	}
 
-	filePath := filepath.Join("/dev", mtdMap["dev"])
-	fileSize, err := strconv.ParseUint(mtdMap["size"], 16, 64)
+	filePath := filepath.Join("/dev", mtdInfo.Dev)
 	if err != nil {
 		return nil, errors.Errorf("Found MTD entry for flash device 'mtd:%v' but got error '%v'",
 			deviceSpecifier, err)
@@ -51,7 +49,7 @@ func getMTD(deviceSpecifier string) (FlashDevice, error) {
 	return &MemoryTechnologyDevice{
 		deviceSpecifier,
 		filePath,
-		fileSize,
+		uint64(mtdInfo.Size),
 	}, nil
 }
 

--- a/tools/flashy/lib/flash/flashutils/devices/mtd_test.go
+++ b/tools/flashy/lib/flash/flashutils/devices/mtd_test.go
@@ -78,7 +78,7 @@ func TestGetMTD(t *testing.T) {
 			want: &MemoryTechnologyDevice{
 				"flash0",
 				"/dev/mtd5",
-				uint64(33554432),
+				uint64(0x02000000),
 			},
 			wantErr: nil,
 		},
@@ -104,8 +104,7 @@ func TestGetMTD(t *testing.T) {
 			procMtdContents: `mtd0: 10000000000000000 00100000 "flash1"`, // larger than 64-bits
 			readFileErr:     nil,
 			want:            nil,
-			wantErr: errors.Errorf("Found MTD entry for flash device 'mtd:flash1' " +
-				"but got error 'strconv.ParseUint: parsing \"10000000000000000\": value out of range'"),
+			wantErr:         errors.Errorf("Failed to parse size: strconv.ParseUint: parsing \"10000000000000000\": value out of range"),
 		},
 		{
 			name:            "corrupt /proc/mtd file",

--- a/tools/flashy/lib/utils/system_test.go
+++ b/tools/flashy/lib/utils/system_test.go
@@ -834,7 +834,7 @@ func TestCheckNoBaseNameExistsInProcCmdlinePaths(t *testing.T) {
 	}
 }
 
-func TestGetMTDMapFromSpecifier(t *testing.T) {
+func TestGetMTDInfoFromSpecifier(t *testing.T) {
 	// mock and defer restore ReadFile
 	readFileOrig := fileutils.ReadFile
 	defer func() {
@@ -846,7 +846,7 @@ func TestGetMTDMapFromSpecifier(t *testing.T) {
 		specifier       string
 		procMtdContents string
 		readFileErr     error
-		want            map[string]string
+		want            MtdInfo
 		wantErr         error
 	}{
 		{
@@ -854,10 +854,10 @@ func TestGetMTDMapFromSpecifier(t *testing.T) {
 			specifier:       "flash0",
 			procMtdContents: tests.ExampleWedge100ProcMtdFile,
 			readFileErr:     nil,
-			want: map[string]string{
-				"dev":       "mtd5",
-				"size":      "02000000",
-				"erasesize": "00010000",
+			want: MtdInfo{
+				Dev:       "mtd5",
+				Size:      0x02000000,
+				Erasesize: 0x00010000,
 			},
 			wantErr: nil,
 		},
@@ -866,7 +866,7 @@ func TestGetMTDMapFromSpecifier(t *testing.T) {
 			specifier:       "flash0",
 			procMtdContents: "",
 			readFileErr:     errors.Errorf("ReadFile error"),
-			want:            nil,
+			want:            MtdInfo{},
 			wantErr:         errors.Errorf("Unable to read from /proc/mtd: ReadFile error"),
 		},
 		{
@@ -874,7 +874,7 @@ func TestGetMTDMapFromSpecifier(t *testing.T) {
 			specifier:       "flash1",
 			procMtdContents: tests.ExampleWedge100ProcMtdFile,
 			readFileErr:     nil,
-			want:            nil,
+			want:            MtdInfo{},
 			wantErr:         errors.Errorf("Error finding MTD entry in /proc/mtd for flash device 'mtd:flash1'"),
 		},
 		{
@@ -882,7 +882,7 @@ func TestGetMTDMapFromSpecifier(t *testing.T) {
 			specifier:       "flash1",
 			procMtdContents: `mtd0: xxxxxxxx xxxxxxxx "flash1"`,
 			readFileErr:     nil,
-			want:            nil,
+			want:            MtdInfo{},
 			wantErr:         errors.Errorf("Error finding MTD entry in /proc/mtd for flash device 'mtd:flash1'"),
 		},
 	}
@@ -895,7 +895,7 @@ func TestGetMTDMapFromSpecifier(t *testing.T) {
 				}
 				return []byte(tc.procMtdContents), tc.readFileErr
 			}
-			got, err := GetMTDMapFromSpecifier(tc.specifier)
+			got, err := GetMTDInfoFromSpecifier(tc.specifier)
 			tests.CompareTestErrors(tc.wantErr, err, t)
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Errorf("want '%v' got '%v'", tc.want, got)

--- a/tools/flashy/lib/utils/vboot.go
+++ b/tools/flashy/lib/utils/vboot.go
@@ -124,7 +124,7 @@ func decodeVbs(vbsData []byte) (Vbs, error) {
 
 var vbootPartitionExists = func() bool {
 	// check whether the "rom" partition exists
-	_, err := GetMTDMapFromSpecifier("rom")
+	_, err := GetMTDInfoFromSpecifier("rom")
 	return err == nil
 }
 


### PR DESCRIPTION
# Summary

`GetMTDMapFromSpecifier` would require the user to access the regex results using string keys, which is not ideal. Return instead a new `MtdInfo` struct that can be accessed safely.

## Test plan
Unit tests pass. (`go test ./...`)