### PR TITLE
flashy: Fix staticcheck and misc. warnings

### DIFF
--- a/tools/flashy/checks_and_remediations/common/00_check_other_flasher_running.go
+++ b/tools/flashy/checks_and_remediations/common/00_check_other_flasher_running.go
@@ -44,7 +44,7 @@ func checkOtherFlasherRunning(stepParams step.StepParams) step.StepExitError {
 	err := utils.CheckOtherFlasherRunning(flashyStepBaseNames)
 	if err != nil {
 		return step.ExitUnsafeToReboot{
-			errors.Errorf("Another flasher detected: %v. "+
+			Err: errors.Errorf("Another flasher detected: %v. "+
 				"Use the '--clowntown' flag if you wish to proceed at the risk of "+
 				"bricking the device", err),
 		}

--- a/tools/flashy/checks_and_remediations/common/00_check_other_flasher_running_test.go
+++ b/tools/flashy/checks_and_remediations/common/00_check_other_flasher_running_test.go
@@ -55,7 +55,7 @@ func TestCheckOtherFlasherRunning(t *testing.T) {
 			clowntown:                   false,
 			checkOtherFlasherRunningErr: errors.Errorf("pypartition"),
 			want: step.ExitUnsafeToReboot{
-				errors.Errorf("Another flasher detected: %v. "+
+				Err: errors.Errorf("Another flasher detected: %v. "+
 					"Use the '--clowntown' flag if you wish to proceed at the risk of "+
 					"bricking the device", "pypartition"),
 			},

--- a/tools/flashy/checks_and_remediations/common/10_truncate_logs.go
+++ b/tools/flashy/checks_and_remediations/common/10_truncate_logs.go
@@ -62,7 +62,7 @@ func truncateLogs(stepParams step.StepParams) step.StepExitError {
 	logFilesToDelete, err := fileutils.GlobAll(deleteLogFilePatterns)
 	if err != nil {
 		errMsg := errors.Errorf("Unable to resolve file patterns '%v': %v", deleteLogFilePatterns, err)
-		return step.ExitSafeToReboot{errMsg}
+		return step.ExitSafeToReboot{Err: errMsg}
 	}
 
 	for _, f := range logFilesToDelete {
@@ -74,7 +74,7 @@ func truncateLogs(stepParams step.StepParams) step.StepExitError {
 	logFilesToTruncate, err := fileutils.GlobAll(truncateLogFilePatterns)
 	if err != nil {
 		errMsg := errors.Errorf("Unable to resolve file patterns '%v': %v", deleteLogFilePatterns, err)
-		return step.ExitSafeToReboot{errMsg}
+		return step.ExitSafeToReboot{Err: errMsg}
 	}
 
 	for _, f := range logFilesToTruncate {

--- a/tools/flashy/checks_and_remediations/common/10_truncate_logs_test.go
+++ b/tools/flashy/checks_and_remediations/common/10_truncate_logs_test.go
@@ -61,11 +61,11 @@ func TestTruncateLogs(t *testing.T) {
 		{
 			name: "Normal operation",
 			resolvedFilePatterns: []GlobAllReturnType{
-				GlobAllReturnType{
+				{
 					[]string{"/tmp/test"},
 					nil,
 				},
-				GlobAllReturnType{
+				{
 					[]string{"/tmp/test"},
 					nil,
 				},
@@ -77,34 +77,34 @@ func TestTruncateLogs(t *testing.T) {
 		{
 			name: "Resolve file patterns error (1)",
 			resolvedFilePatterns: []GlobAllReturnType{
-				GlobAllReturnType{
+				{
 					nil,
 					errors.Errorf("resolveFilePatterns Error"),
 				},
-				GlobAllReturnType{
+				{
 					[]string{"/tmp/test"},
 					nil,
 				},
 			},
 			removeFileErr:   nil,
 			truncateFileErr: nil,
-			want:            step.ExitSafeToReboot{errors.Errorf("Unable to resolve file patterns '%v': resolveFilePatterns Error", deleteLogFilePatterns)},
+			want:            step.ExitSafeToReboot{Err: errors.Errorf("Unable to resolve file patterns '%v': resolveFilePatterns Error", deleteLogFilePatterns)},
 		},
 		{
 			name: "Resolve file patterns error (2)",
 			resolvedFilePatterns: []GlobAllReturnType{
-				GlobAllReturnType{
+				{
 					[]string{"/tmp/test"},
 					nil,
 				},
-				GlobAllReturnType{
+				{
 					nil,
 					errors.Errorf("resolveFilePatterns Error"),
 				},
 			},
 			removeFileErr:   nil,
 			truncateFileErr: nil,
-			want:            step.ExitSafeToReboot{errors.Errorf("Unable to resolve file patterns '%v': resolveFilePatterns Error", deleteLogFilePatterns)},
+			want:            step.ExitSafeToReboot{Err: errors.Errorf("Unable to resolve file patterns '%v': resolveFilePatterns Error", deleteLogFilePatterns)},
 		},
 	}
 

--- a/tools/flashy/checks_and_remediations/common/11_drop_caches.go
+++ b/tools/flashy/checks_and_remediations/common/11_drop_caches.go
@@ -41,7 +41,7 @@ func dropCaches(stepParams step.StepParams) step.StepExitError {
 	)
 	if err != nil {
 		errMsg := errors.Errorf("Failed to write to drop_caches file '%v': %v", dropCachesFilePath, err)
-		return step.ExitSafeToReboot{errMsg}
+		return step.ExitSafeToReboot{Err: errMsg}
 	}
 	return nil
 }

--- a/tools/flashy/checks_and_remediations/common/11_drop_caches_test.go
+++ b/tools/flashy/checks_and_remediations/common/11_drop_caches_test.go
@@ -50,7 +50,7 @@ func TestDropCaches(t *testing.T) {
 			name:         "WriteFile failed",
 			writeFileErr: errors.Errorf("WriteFile failed"),
 			want: step.ExitSafeToReboot{
-				errors.Errorf(
+				Err: errors.Errorf(
 					"Failed to write to drop_caches file '/proc/sys/vm/drop_caches': WriteFile failed",
 				),
 			},

--- a/tools/flashy/checks_and_remediations/common/12_remove_healthd_reboot.go
+++ b/tools/flashy/checks_and_remediations/common/12_remove_healthd_reboot.go
@@ -38,11 +38,11 @@ func removeHealthdReboot(stepParams step.StepParams) step.StepExitError {
 			"\"reboot\" entry if it exists.")
 		healthdConfig, err := utils.GetHealthdConfig()
 		if err != nil {
-			return step.ExitSafeToReboot{err}
+			return step.ExitSafeToReboot{Err: err}
 		}
 		err = utils.HealthdRemoveMemUtilRebootEntryIfExists(healthdConfig)
 		if err != nil {
-			return step.ExitSafeToReboot{err}
+			return step.ExitSafeToReboot{Err: err}
 		}
 	} else {
 		log.Printf("Healthd does not exist in this system. Skipping step.")

--- a/tools/flashy/checks_and_remediations/common/12_remove_healthd_reboot_test.go
+++ b/tools/flashy/checks_and_remediations/common/12_remove_healthd_reboot_test.go
@@ -101,7 +101,7 @@ func TestRemoveHealthdReboot(t *testing.T) {
 			wantConfig:        "",
 			logContainsSeq:    []string{},
 			want: step.ExitSafeToReboot{
-				errors.Errorf("Unable to parse healthd-config.json: " +
+				Err: errors.Errorf("Unable to parse healthd-config.json: " +
 					"invalid character 'F' looking for beginning of object key string"),
 			},
 		},
@@ -113,7 +113,7 @@ func TestRemoveHealthdReboot(t *testing.T) {
 			wantConfig:        "",
 			logContainsSeq:    []string{},
 			want: step.ExitSafeToReboot{
-				errors.Errorf("Can't get 'bmc_mem_utilization.threshold' entry in healthd-config " +
+				Err: errors.Errorf("Can't get 'bmc_mem_utilization.threshold' entry in healthd-config " +
 					"{\"foo\":\"foo\"}"),
 			},
 		},

--- a/tools/flashy/checks_and_remediations/common/13_restart_services.go
+++ b/tools/flashy/checks_and_remediations/common/13_restart_services.go
@@ -38,7 +38,7 @@ func restartServices(stepParams step.StepParams) step.StepExitError {
 	systemdAvail, err := utils.SystemdAvailable()
 	if err != nil {
 		errMsg := errors.Errorf("Error checking systemd availability: %v", err)
-		return step.ExitSafeToReboot{errMsg}
+		return step.ExitSafeToReboot{Err: errMsg}
 	}
 
 	if systemdAvail {
@@ -66,7 +66,7 @@ func restartServices(stepParams step.StepParams) step.StepExitError {
 		log.Printf("Healthd exists, attempting to restart healthd...")
 		err = utils.RestartHealthd(true, supervisor)
 		if err != nil {
-			return step.ExitSafeToReboot{err}
+			return step.ExitSafeToReboot{Err: err}
 		} else {
 			log.Printf("Finished restarting healthd")
 		}

--- a/tools/flashy/checks_and_remediations/common/13_restart_services_test.go
+++ b/tools/flashy/checks_and_remediations/common/13_restart_services_test.go
@@ -76,7 +76,7 @@ func TestRestartServices(t *testing.T) {
 			systemdAvailErr:   errors.Errorf("Systemd check error"),
 			runCmdErr:         nil,
 			restartHealthdErr: nil,
-			want:              step.ExitSafeToReboot{errors.Errorf("Error checking systemd availability: Systemd check error")},
+			want:              step.ExitSafeToReboot{Err: errors.Errorf("Error checking systemd availability: Systemd check error")},
 			wantCmds:          []string{},
 		},
 		{
@@ -94,7 +94,7 @@ func TestRestartServices(t *testing.T) {
 			systemdAvailErr:   nil,
 			runCmdErr:         nil,
 			restartHealthdErr: errors.Errorf("Healthd restart error"),
-			want:              step.ExitSafeToReboot{errors.Errorf("Healthd restart error")},
+			want:              step.ExitSafeToReboot{Err: errors.Errorf("Healthd restart error")},
 			wantCmds:          []string{"systemctl restart restapi"},
 		},
 	}

--- a/tools/flashy/checks_and_remediations/common/20_unmount_data_partition.go
+++ b/tools/flashy/checks_and_remediations/common/20_unmount_data_partition.go
@@ -47,7 +47,7 @@ func unmountDataPartition(stepParams step.StepParams) step.StepExitError {
 	dataMounted, err := utils.IsDataPartitionMounted()
 	if err != nil {
 		return step.ExitSafeToReboot{
-			errors.Errorf("Unable to determine whether /mnt/data is mounted: %v",
+			Err: errors.Errorf("Unable to determine whether /mnt/data is mounted: %v",
 				err),
 		}
 	}
@@ -73,7 +73,7 @@ func unmountDataPartition(stepParams step.StepParams) step.StepExitError {
 			if err != nil {
 				log.Printf("/mnt/data remount failed: %v", err)
 				return step.ExitSafeToReboot{
-					errors.Errorf("Failed to unmount or remount /mnt/data"),
+					Err: errors.Errorf("Failed to unmount or remount /mnt/data"),
 				}
 			}
 		}
@@ -82,7 +82,7 @@ func unmountDataPartition(stepParams step.StepParams) step.StepExitError {
 		err = validateSshdConfig()
 		if err != nil {
 			return step.ExitUnsafeToReboot{
-				errors.Errorf("Validate sshd config failed: %v", err),
+				Err: errors.Errorf("Validate sshd config failed: %v", err),
 			}
 		}
 	} else {

--- a/tools/flashy/checks_and_remediations/common/20_unmount_data_partition_test.go
+++ b/tools/flashy/checks_and_remediations/common/20_unmount_data_partition_test.go
@@ -83,7 +83,7 @@ func TestUnmountDataPartition(t *testing.T) {
 			remountErr:     nil,
 			sshdConfigErr:  nil,
 			want: step.ExitSafeToReboot{
-				errors.Errorf("Unable to determine whether /mnt/data is mounted: check failed"),
+				Err: errors.Errorf("Unable to determine whether /mnt/data is mounted: check failed"),
 			},
 		},
 		{
@@ -103,7 +103,7 @@ func TestUnmountDataPartition(t *testing.T) {
 			remountErr:     errors.Errorf("remount failed"),
 			sshdConfigErr:  nil,
 			want: step.ExitSafeToReboot{
-				errors.Errorf("Failed to unmount or remount /mnt/data"),
+				Err: errors.Errorf("Failed to unmount or remount /mnt/data"),
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestUnmountDataPartition(t *testing.T) {
 			remountErr:     nil,
 			sshdConfigErr:  errors.Errorf("sshd config corrupt"),
 			want: step.ExitUnsafeToReboot{
-				errors.Errorf("Validate sshd config failed: %v",
+				Err: errors.Errorf("Validate sshd config failed: %v",
 					"sshd config corrupt"),
 			},
 		},

--- a/tools/flashy/checks_and_remediations/common/30_ensure_enough_free_ram.go
+++ b/tools/flashy/checks_and_remediations/common/30_ensure_enough_free_ram.go
@@ -39,7 +39,7 @@ const minMemoryNeeded = 45 * 1024 * 1024
 func ensureEnoughFreeRAM(stepParams step.StepParams) step.StepExitError {
 	memInfo, err := utils.GetMemInfo()
 	if err != nil {
-		return step.ExitSafeToReboot{err}
+		return step.ExitSafeToReboot{Err: err}
 	}
 	log.Printf("Memory status: %v B total memory, %v B free memory", memInfo.MemTotal, memInfo.MemFree)
 	log.Printf("Minimum memory needed for update is %v B", minMemoryNeeded)
@@ -47,7 +47,7 @@ func ensureEnoughFreeRAM(stepParams step.StepParams) step.StepExitError {
 	if memInfo.MemFree < minMemoryNeeded {
 		errMsg := errors.Errorf("Free memory (%v B) < minimum memory needed (%v B), reboot needed",
 			memInfo.MemFree, minMemoryNeeded)
-		return step.ExitSafeToReboot{errMsg}
+		return step.ExitSafeToReboot{Err: errMsg}
 	}
 
 	return nil

--- a/tools/flashy/checks_and_remediations/common/30_ensure_enough_free_ram_test.go
+++ b/tools/flashy/checks_and_remediations/common/30_ensure_enough_free_ram_test.go
@@ -42,8 +42,8 @@ func TestEnsureEnoughFreeRAM(t *testing.T) {
 		{
 			name: "Enough free ram",
 			memInfo: &utils.MemInfo{
-				120 * 1024 * 1024,
-				50 * 1024 * 1024,
+				MemTotal: 120 * 1024 * 1024,
+				MemFree:  50 * 1024 * 1024,
 			},
 			memInfoErr: nil,
 			want:       nil,
@@ -51,19 +51,19 @@ func TestEnsureEnoughFreeRAM(t *testing.T) {
 		{
 			name: "Not enough free ram",
 			memInfo: &utils.MemInfo{
-				120 * 1024 * 1024,
-				30 * 1024 * 1024,
+				MemTotal: 120 * 1024 * 1024,
+				MemFree:  30 * 1024 * 1024,
 			},
 			memInfoErr: nil,
 			want: step.ExitSafeToReboot{
-				errors.Errorf("Free memory (31457280 B) < minimum memory needed (47185920 B), reboot needed"),
+				Err: errors.Errorf("Free memory (31457280 B) < minimum memory needed (47185920 B), reboot needed"),
 			},
 		},
 		{
 			name:       "Error in GetMemInfo",
 			memInfo:    nil,
 			memInfoErr: errors.Errorf("MemInfo error"),
-			want:       step.ExitSafeToReboot{errors.Errorf("MemInfo error")},
+			want:       step.ExitSafeToReboot{Err: errors.Errorf("MemInfo error")},
 		},
 	}
 

--- a/tools/flashy/checks_and_remediations/common/40_validate_image_buildname.go
+++ b/tools/flashy/checks_and_remediations/common/40_validate_image_buildname.go
@@ -41,7 +41,7 @@ func validateImageBuildname(stepParams step.StepParams) step.StepExitError {
 	err := validate.CheckImageBuildNameCompatibility(stepParams.ImageFilePath)
 	if err != nil {
 		return step.ExitUnknownError{
-			errors.Errorf("Image build name compatibility check failed: %v. "+
+			Err: errors.Errorf("Image build name compatibility check failed: %v. "+
 				"Use the '--clowntown' flag if you wish to proceed at the risk of "+
 				"bricking the device", err),
 		}

--- a/tools/flashy/checks_and_remediations/common/40_validate_image_buildname_test.go
+++ b/tools/flashy/checks_and_remediations/common/40_validate_image_buildname_test.go
@@ -50,7 +50,7 @@ func TestValidateImageBuildname(t *testing.T) {
 			clowntown:        false,
 			compatibilityErr: errors.Errorf("compatibility failed"),
 			want: step.ExitUnknownError{
-				errors.Errorf("Image build name compatibility check failed: " +
+				Err: errors.Errorf("Image build name compatibility check failed: " +
 					"compatibility failed. Use the '--clowntown' flag if you wish " +
 					"to proceed at the risk of bricking the device"),
 			},

--- a/tools/flashy/checks_and_remediations/common/41_validate_image_partitions.go
+++ b/tools/flashy/checks_and_remediations/common/41_validate_image_partitions.go
@@ -47,7 +47,7 @@ func validateImagePartitions(stepParams step.StepParams) step.StepExitError {
 	if err != nil {
 		// the image could've been corrupted during copy,
 		// it is safe to reboot.
-		return step.ExitSafeToReboot{err}
+		return step.ExitSafeToReboot{Err: err}
 	}
 	return nil
 }

--- a/tools/flashy/checks_and_remediations/common/41_validate_image_partitions_test.go
+++ b/tools/flashy/checks_and_remediations/common/41_validate_image_partitions_test.go
@@ -64,7 +64,7 @@ func TestValidateImagePartitions(t *testing.T) {
 			isPfrSystem:   false,
 			validateError: errors.Errorf("validation failed"),
 			want: step.ExitSafeToReboot{
-				errors.Errorf("validation failed"),
+				Err: errors.Errorf("validation failed"),
 			},
 		},
 		{

--- a/tools/flashy/checks_and_remediations/wedge100/00_fix_romcs1.go
+++ b/tools/flashy/checks_and_remediations/wedge100/00_fix_romcs1.go
@@ -43,7 +43,7 @@ func fixROMCS1(stepParams step.StepParams) step.StepExitError {
 		60*time.Second)
 	if err != nil {
 		errMsg := errors.Errorf("Failed to run ROMCS1# fix: %v", err)
-		return step.ExitSafeToReboot{errMsg}
+		return step.ExitSafeToReboot{Err: errMsg}
 	}
 	return nil
 }

--- a/tools/flashy/install/install.go
+++ b/tools/flashy/install/install.go
@@ -91,10 +91,10 @@ func cleanInstallPath() {
 	exDir := filepath.Dir(exPath)
 
 	d, err := os.Open(exDir)
-	defer d.Close()
 	if err != nil {
 		log.Fatalf("Unable to open installation directory: '%v'", err)
 	}
+	defer d.Close()
 	dirnames, err := d.Readdirnames(-1)
 	if err != nil {
 		log.Fatalf("Unable to read installation directory: '%v'", err)

--- a/tools/flashy/lib/fileutils/fileutils.go
+++ b/tools/flashy/lib/fileutils/fileutils.go
@@ -178,7 +178,7 @@ var IsELFFile = func(filename string) bool {
 			"assuming that it is not an ELF file", filename, err)
 		return false
 	}
-	return bytes.Compare(buf, elfMagicNumber) == 0
+	return bytes.Equal(buf, elfMagicNumber)
 }
 
 // MmapFile is a convenience function to mmap an entire file.

--- a/tools/flashy/lib/flash/flashcp/flashcp.go
+++ b/tools/flashy/lib/flash/flashcp/flashcp.go
@@ -70,8 +70,6 @@ type erase_info_user struct {
 	length uint32
 }
 
-const erase_info_user_size = 64
-
 // linux/include/uapi/mtd/mtd-abi.h
 type mtd_info_user struct {
 	_type     uint8
@@ -346,8 +344,8 @@ var verifyFlash = func(
 	activeFlashData := flashData[roOffset:]
 
 	if !bytes.Equal(activeFlashData, activeImageData) {
-		errMsg := fmt.Sprintf("Verification failed: flash and image data mismatch.")
-		log.Printf(errMsg)
+		errMsg := "Verification failed: flash and image data mismatch."
+		log.Print(errMsg)
 		return errors.Errorf("%v", errMsg)
 	}
 

--- a/tools/flashy/lib/flash/flashcp_step.go
+++ b/tools/flashy/lib/flash/flashcp_step.go
@@ -38,14 +38,14 @@ func FlashCp(stepParams step.StepParams) step.StepExitError {
 	log.Printf("Getting flash target device")
 	flashDevice, err := flashutils.GetFlashDevice(stepParams.DeviceID)
 	if err != nil {
-		log.Printf(err.Error())
-		return step.ExitSafeToReboot{err}
+		log.Print(err.Error())
+		return step.ExitSafeToReboot{Err: err}
 	}
 	log.Printf("Flash device: %v", flashDevice)
 	err = flashCpAndValidate(flashDevice, stepParams.ImageFilePath, 0)
 	if err != nil {
 		// failed validation considered to be a deal breaker
-		return step.ExitUnsafeToReboot{err}
+		return step.ExitUnsafeToReboot{Err: err}
 	}
 
 	// make sure no other flasher is running
@@ -53,7 +53,7 @@ func FlashCp(stepParams step.StepParams) step.StepExitError {
 	err = utils.CheckOtherFlasherRunning(flashyStepBaseNames)
 	if err != nil {
 		log.Printf("Flashing succeeded but found another flasher running: %v", err)
-		return step.ExitUnsafeToReboot{err}
+		return step.ExitUnsafeToReboot{Err: err}
 	}
 
 	return nil

--- a/tools/flashy/lib/flash/flashcp_step_test.go
+++ b/tools/flashy/lib/flash/flashcp_step_test.go
@@ -69,9 +69,9 @@ func TestFlashCp(t *testing.T) {
 	}
 
 	exampleFlashDevice := &devices.MemoryTechnologyDevice{
-		"flash0",
-		"/dev/mtd5",
-		uint64(12345678),
+		Specifier: "flash0",
+		FilePath:  "/dev/mtd5",
+		FileSize:  uint64(12345678),
 	}
 
 	cases := []struct {
@@ -100,7 +100,7 @@ func TestFlashCp(t *testing.T) {
 			flashCpAndValidateErr: nil,
 			otherFlasherErr:       nil,
 			want: step.ExitSafeToReboot{
-				errors.Errorf("GetFlashDevice error"),
+				Err: errors.Errorf("GetFlashDevice error"),
 			},
 			logContainsSeq: []string{
 				"Flashing using flashcp method",
@@ -114,7 +114,7 @@ func TestFlashCp(t *testing.T) {
 			flashCpAndValidateErr: errors.Errorf("RunCommand error"),
 			otherFlasherErr:       nil,
 			want: step.ExitUnsafeToReboot{
-				errors.Errorf("RunCommand error"),
+				Err: errors.Errorf("RunCommand error"),
 			},
 			logContainsSeq: []string{
 				"Flashing using flashcp method",
@@ -128,7 +128,7 @@ func TestFlashCp(t *testing.T) {
 			flashCpAndValidateErr: nil,
 			otherFlasherErr:       errors.Errorf("Found other flasher!"),
 			want: step.ExitUnsafeToReboot{
-				errors.Errorf("Found other flasher!"),
+				Err: errors.Errorf("Found other flasher!"),
 			},
 			logContainsSeq: []string{
 				"Flashing succeeded but found another flasher running",

--- a/tools/flashy/lib/flash/flashcpvboot_step.go
+++ b/tools/flashy/lib/flash/flashcpvboot_step.go
@@ -55,8 +55,8 @@ func FlashCpVboot(stepParams step.StepParams) step.StepExitError {
 	log.Printf("Getting flash target device")
 	flashDevice, err := flashutils.GetFlashDevice(stepParams.DeviceID)
 	if err != nil {
-		log.Printf(err.Error())
-		return step.ExitSafeToReboot{err}
+		log.Print(err.Error())
+		return step.ExitSafeToReboot{Err: err}
 	}
 	log.Printf("Flash device: %v", flashDevice)
 
@@ -76,7 +76,7 @@ func FlashCpVboot(stepParams step.StepParams) step.StepExitError {
 		// return safe to reboot here to retry.
 		// error handler (step.HandleStepError) will check if
 		// either flash device is valid.
-		return step.ExitSafeToReboot{err}
+		return step.ExitSafeToReboot{Err: err}
 	}
 
 	// make sure no other flasher is running
@@ -84,7 +84,7 @@ func FlashCpVboot(stepParams step.StepParams) step.StepExitError {
 	err = utils.CheckOtherFlasherRunning(flashyStepBaseNames)
 	if err != nil {
 		log.Printf("Flashing succeeded but found another flasher running: %v", err)
-		return step.ExitUnsafeToReboot{err}
+		return step.ExitUnsafeToReboot{Err: err}
 	}
 
 	return nil

--- a/tools/flashy/lib/flash/flashcpvboot_step_test.go
+++ b/tools/flashy/lib/flash/flashcpvboot_step_test.go
@@ -104,9 +104,9 @@ func TestFlashCpVboot(t *testing.T) {
 	}
 
 	exampleFlashDevice := &devices.MemoryTechnologyDevice{
-		"flash0",
-		"/dev/mtd5",
-		uint64(12345678),
+		Specifier: "flash0",
+		FilePath:  "/dev/mtd5",
+		FileSize:  uint64(12345678),
 	}
 
 	cases := []struct {
@@ -138,7 +138,7 @@ func TestFlashCpVboot(t *testing.T) {
 			vbootSkipNeeded:       false,
 			otherFlasherErr:       nil,
 			want: step.ExitSafeToReboot{
-				errors.Errorf("GetFlashDevice error"),
+				Err: errors.Errorf("GetFlashDevice error"),
 			},
 			logContainsSeq: []string{
 				"Flashing using flashcp vboot method",
@@ -153,7 +153,7 @@ func TestFlashCpVboot(t *testing.T) {
 			vbootSkipNeeded:       false,
 			otherFlasherErr:       nil,
 			want: step.ExitSafeToReboot{
-				errors.Errorf("RunCommand error"),
+				Err: errors.Errorf("RunCommand error"),
 			},
 			logContainsSeq: []string{
 				"Flashing using flashcp vboot method",
@@ -168,7 +168,7 @@ func TestFlashCpVboot(t *testing.T) {
 			vbootSkipNeeded:       false,
 			otherFlasherErr:       errors.Errorf("Found other flasher!"),
 			want: step.ExitUnsafeToReboot{
-				errors.Errorf("Found other flasher!"),
+				Err: errors.Errorf("Found other flasher!"),
 			},
 			logContainsSeq: []string{
 				"Flashing succeeded but found another flasher running",

--- a/tools/flashy/lib/flash/flashfwutil_step.go
+++ b/tools/flashy/lib/flash/flashfwutil_step.go
@@ -38,7 +38,7 @@ func FlashFwUtil(stepParams step.StepParams) step.StepExitError {
 
 	err := runFwUtilCmd(stepParams.ImageFilePath)
 	if err != nil {
-		return step.ExitSafeToReboot{err}
+		return step.ExitSafeToReboot{Err: err}
 	}
 
 	// make sure no other flasher is running
@@ -46,7 +46,7 @@ func FlashFwUtil(stepParams step.StepParams) step.StepExitError {
 	err = utils.CheckOtherFlasherRunning(flashyStepBaseNames)
 	if err != nil {
 		log.Printf("Flashing succeeded but found another flasher running: %v", err)
-		return step.ExitUnsafeToReboot{err}
+		return step.ExitUnsafeToReboot{Err: err}
 	}
 
 	return nil

--- a/tools/flashy/lib/flash/flashfwutil_step_test.go
+++ b/tools/flashy/lib/flash/flashfwutil_step_test.go
@@ -73,7 +73,7 @@ func TestFlashFwUtil(t *testing.T) {
 			runFwUtilCmdErr: errors.Errorf("RunCommand error"),
 			otherFlasherErr: nil,
 			want: step.ExitSafeToReboot{
-				errors.Errorf("RunCommand error"),
+				Err: errors.Errorf("RunCommand error"),
 			},
 			logContainsSeq: []string{
 				"Flashing using fw-util method",
@@ -85,7 +85,7 @@ func TestFlashFwUtil(t *testing.T) {
 			runFwUtilCmdErr: nil,
 			otherFlasherErr: errors.Errorf("Found other flasher!"),
 			want: step.ExitUnsafeToReboot{
-				errors.Errorf("Found other flasher!"),
+				Err: errors.Errorf("Found other flasher!"),
 			},
 			logContainsSeq: []string{
 				"Flashing succeeded but found another flasher running",

--- a/tools/flashy/lib/flash/flashutils/devices/mtd_test.go
+++ b/tools/flashy/lib/flash/flashutils/devices/mtd_test.go
@@ -190,7 +190,7 @@ func TestMmapRO(t *testing.T) {
 			got, err := testMtd.MmapRO()
 
 			tests.CompareTestErrors(tc.wantErr, err, t)
-			if bytes.Compare(tc.want, got) != 0 {
+			if !bytes.Equal(tc.want, got) {
 				t.Errorf("want '%v' got '%v'", tc.want, got)
 			}
 		})

--- a/tools/flashy/lib/logger/logger.go
+++ b/tools/flashy/lib/logger/logger.go
@@ -101,7 +101,7 @@ var StartSyslog = func() {
 		log.Printf("Unable to decide if systemd is available: %v", err)
 		return
 	}
-	cmd := []string{}
+	var cmd []string
 	if systemdAvail {
 		cmd = []string{"systemctl", "start", "syslog"}
 	} else {

--- a/tools/flashy/lib/step/error_test.go
+++ b/tools/flashy/lib/step/error_test.go
@@ -52,19 +52,19 @@ func TestHandleStepError(t *testing.T) {
 		},
 		{
 			name:                  "unsafe to reboot",
-			stepExitError:         ExitUnsafeToReboot{errors.Errorf("err")},
+			stepExitError:         ExitUnsafeToReboot{Err: errors.Errorf("err")},
 			ensureSafeToRebootErr: nil,
 			wantExitCode:          FLASHY_ERROR_UNSAFE_TO_REBOOT,
 		},
 		{
 			name:                  "safe to reboot, ensured OK",
-			stepExitError:         ExitSafeToReboot{errors.Errorf("err")},
+			stepExitError:         ExitSafeToReboot{Err: errors.Errorf("err")},
 			ensureSafeToRebootErr: nil,
 			wantExitCode:          FLASHY_ERROR_SAFE_TO_REBOOT,
 		},
 		{
 			name:                  "safe to reboot, but ensure check failed",
-			stepExitError:         ExitSafeToReboot{errors.Errorf("err")},
+			stepExitError:         ExitSafeToReboot{Err: errors.Errorf("err")},
 			ensureSafeToRebootErr: errors.Errorf("actually unsafe"),
 			wantExitCode:          FLASHY_ERROR_UNSAFE_TO_REBOOT,
 		},

--- a/tools/flashy/lib/step/step.go
+++ b/tools/flashy/lib/step/step.go
@@ -56,7 +56,7 @@ func RegisterStep(step func(StepParams) StepExitError) {
 // GetFlashyStepBaseNames gets basenames of flashy's steps.
 var GetFlashyStepBaseNames = func() []string {
 	flashyStepBaseNames := []string{}
-	for p, _ := range StepMap {
+	for p := range StepMap {
 		stepBasename := path.Base(p)
 		flashyStepBaseNames = append(flashyStepBaseNames, stepBasename)
 	}

--- a/tools/flashy/lib/utils/helper_test.go
+++ b/tools/flashy/lib/utils/helper_test.go
@@ -445,10 +445,10 @@ func TestSafeAppendBytes(t *testing.T) {
 	b[0] = 'y'
 	c := SafeAppendBytes(a, b)
 
-	if bytes.Compare(a, []byte{'x'}) != 0 {
+	if !bytes.Equal(a, []byte{'x'}) {
 		t.Errorf("a: want '%v' got '%v'", []byte{'x'}, a)
 	}
-	if bytes.Compare(c, []byte{'x', 'y'}) != 0 {
+	if !bytes.Equal(c, []byte{'x', 'y'}) {
 		t.Errorf("c: want '%v' got '%v'", []byte{'x', 'y'}, c)
 	}
 }
@@ -530,7 +530,7 @@ func TestSetWord(t *testing.T) {
 	}
 	for _, tc := range cases {
 		got, err := SetWord(tc.data, tc.word, tc.offset)
-		if bytes.Compare(tc.want, got) != 0 {
+		if !bytes.Equal(tc.want, got) {
 			t.Errorf("want '%v' got '%v'", tc.want, got)
 		}
 		tests.CompareTestErrors(tc.wantErr, err, t)

--- a/tools/flashy/lib/utils/vboot_test.go
+++ b/tools/flashy/lib/utils/vboot_test.go
@@ -162,7 +162,7 @@ func TestGetVbs(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if bytes.Compare(data, tests.ExampleVbsData) != 0 {
+	if !bytes.Equal(data, tests.ExampleVbsData) {
 		t.Errorf("encode failed: want '%v' got '%v'", tests.ExampleVbsData, data)
 	}
 

--- a/tools/flashy/lib/validate/partition/p_fbmeta.go
+++ b/tools/flashy/lib/validate/partition/p_fbmeta.go
@@ -43,7 +43,8 @@ var fbmetaImagePartitionFactory = func(args PartitionFactoryArgs) Partition {
 }
 
 // supported FBOBMC_IMAGE_META_VER
-var fbmetaSupportedVersions = []int{1}
+// TODO:- check version when there are more than one versions for fbmeta
+// var fbmetaSupportedVersions = []int{1}
 
 const fbmetaImageMetaPartitionSize = 64 * 1024
 const fbmetaImageMetaPartitionOffset = 0x000F0000

--- a/tools/flashy/lib/validate/partition/p_fbmeta_test.go
+++ b/tools/flashy/lib/validate/partition/p_fbmeta_test.go
@@ -142,7 +142,7 @@ func TestFBMetaValidate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			parseAndValidateFBImageMetaJSON = func(data []byte) (FBMetaInfo, error) {
-				if bytes.Compare(exampleMetaPartitionData, data) != 0 {
+				if !bytes.Equal(exampleMetaPartitionData, data) {
 					t.Errorf("data passed into parseAndValidateImageMetaJSON incorrect")
 				}
 				return exampleMetaInfo, tc.parseAndValidateFBImageMetaJSONErr
@@ -158,7 +158,7 @@ func TestFBMetaValidate(t *testing.T) {
 				data []byte,
 				partitionConfigs []PartitionConfigInfo,
 			) error {
-				if bytes.Compare(exampleData, data) != 0 {
+				if !bytes.Equal(exampleData, data) {
 					t.Errorf("data passed into ValidatePartitionsFromPartitionConfigs incorrect")
 				}
 				if !reflect.DeepEqual(examplePartitionConfigs, partitionConfigs) {
@@ -370,7 +370,7 @@ func TestGetPartitionConfigsFromFBMetaPartInfos(t *testing.T) {
 		{
 			name: "invalid meta part info type",
 			metaPartInfos: []FBMetaPartInfo{
-				FBMetaPartInfo{
+				{
 					Name:     "one",
 					Size:     1024,
 					Offset:   1024,

--- a/tools/flashy/lib/validate/partition/p_fit.go
+++ b/tools/flashy/lib/validate/partition/p_fit.go
@@ -133,7 +133,7 @@ func (p *FitPartition) validateImageNode(imageNode *dt.Node) error {
 
 	calcChecksumDat := sha256.Sum256(data)
 	calcChecksum := calcChecksumDat[:]
-	if bytes.Compare(checksum, calcChecksum) != 0 {
+	if !bytes.Equal(checksum, calcChecksum) {
 		return errors.Errorf("Calculated sha256 (0x%X) does not match that in FIT (0x%X)",
 			calcChecksum, checksum)
 	}

--- a/tools/flashy/lib/validate/partition/p_fit_test.go
+++ b/tools/flashy/lib/validate/partition/p_fit_test.go
@@ -507,7 +507,7 @@ func TestGetDataFromImageNode(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := p.getDataFromImageNode(tc.imageNode)
-			if bytes.Compare(tc.want, got) != 0 {
+			if !bytes.Equal(tc.want, got) {
 				t.Errorf("want '%v' got '%v'", tc.want, got)
 			}
 			tests.CompareTestErrors(tc.wantErr, err, t)
@@ -574,7 +574,7 @@ func TestGetDataFromImageNodeViaDataProp(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := p.getDataFromImageNodeViaDataProp(tc.imageNode)
 			tests.CompareTestErrors(tc.wantErr, err, t)
-			if bytes.Compare(tc.want, got) != 0 {
+			if !bytes.Equal(tc.want, got) {
 				t.Errorf("want '%v', got '%v'", tc.want, got)
 			}
 		})
@@ -704,7 +704,7 @@ func TestGetDataFromImageNodeViaDataLink(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := p.getDataFromImageNodeViaDataLink(tc.imageNode)
 			tests.CompareTestErrors(tc.wantErr, err, t)
-			if bytes.Compare(tc.want, got) != 0 {
+			if !bytes.Equal(tc.want, got) {
 				t.Errorf("want '%v' got '%v'", tc.want, got)
 			}
 		})
@@ -848,7 +848,7 @@ func TestFitGetSHA256ChecksumFromImageNode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &FitPartition{}
 			got, err := p.getSHA256ChecksumFromImageNode(tc.imageNode)
-			if bytes.Compare(tc.want, got) != 0 {
+			if !bytes.Equal(tc.want, got) {
 				t.Errorf("want '%x' got '%x'", tc.want, got)
 			}
 			tests.CompareTestErrors(tc.wantErr, err, t)
@@ -859,7 +859,7 @@ func TestFitGetSHA256ChecksumFromImageNode(t *testing.T) {
 func TestGetPropertyFromNode(t *testing.T) {
 	node := &dt.Node{
 		Properties: []dt.Property{
-			dt.Property{
+			{
 				Name: "a",
 			},
 		},
@@ -878,7 +878,7 @@ func TestGetPropertyFromNode(t *testing.T) {
 
 func TestGetNodeFromChildren(t *testing.T) {
 	children := []*dt.Node{
-		&dt.Node{
+		{
 			Name: "a",
 		},
 	}

--- a/tools/flashy/lib/validate/partition/p_legacy_uboot_test.go
+++ b/tools/flashy/lib/validate/partition/p_legacy_uboot_test.go
@@ -217,7 +217,7 @@ func TestLegacyUbootHeader(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if bytes.Compare(encoded, mockHeader) != 0 {
+	if !bytes.Equal(encoded, mockHeader) {
 		t.Errorf("encode decode failed: want '%v' got '%v'", mockHeader, encoded)
 	}
 

--- a/tools/flashy/lib/validate/partition/p_uboot.go
+++ b/tools/flashy/lib/validate/partition/p_uboot.go
@@ -289,12 +289,12 @@ func (p *UBootPartition) GetType() PartitionConfigType {
 // check magic
 func (p *UBootPartition) checkMagic() error {
 	// check that p.Data is larger than 4 bytes
-	if len(p.Data) < 4 {
+	if len(p.Data) < ubootMagicSize {
 		return errors.Errorf("'%v' partition too small (%v) to contain U-Boot magic",
 			p.Name, len(p.Data))
 	}
 
-	magic := binary.BigEndian.Uint32(p.Data[:4])
+	magic := binary.BigEndian.Uint32(p.Data[:ubootMagicSize])
 	if utils.Uint32Find(magic, ubootMagics) == -1 {
 		return errors.Errorf("Magic '0x%X' does not match any U-Boot magic", magic)
 	}

--- a/tools/flashy/lib/validate/validate.go
+++ b/tools/flashy/lib/validate/validate.go
@@ -54,7 +54,7 @@ var Validate = func(data []byte) error {
 	}
 
 	errMsg := "*** FAILED: Validation failed ***"
-	log.Printf(errMsg)
+	log.Print(errMsg)
 	return errors.Errorf(errMsg)
 }
 

--- a/tools/flashy/lib/validate/validate_test.go
+++ b/tools/flashy/lib/validate/validate_test.go
@@ -160,7 +160,7 @@ func TestValidateImageFile(t *testing.T) {
 			}
 
 			Validate = func(data []byte) error {
-				if bytes.Compare(data, imageData) != 0 {
+				if !bytes.Equal(data, imageData) {
 					t.Errorf("data: want '%v' got '%v'", imageData, data)
 				}
 				return tc.validateErr


### PR DESCRIPTION
# Summary

As title. No functional changes. 
Errors fixed include those from `staticcheck`, obtained via
`staticcheck ./... | grep -vE 'ST1017|SA9004|ST1008|S1019'` (filtering out annoying warnings)

- Use `bytes.Equal` instead of `bytes.Compare`
- Explicitly specify key when declaring structs
- Remove unneeded struct names
- Close fds after checking error to ensure that it is opened
- Use `Print` instead of `Printf` as necessary
- Remove unused vars/Use them appropriately

## Test plan
Unit tests pass (`go test ./...`)