### PR TITLE
flashy: Check image file size against flash device size

### DIFF
--- a/tools/flashy/checks_and_remediations/common/41_validate_image_partitions.go
+++ b/tools/flashy/checks_and_remediations/common/41_validate_image_partitions.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/facebook/openbmc/tools/flashy/lib/step"
 	"github.com/facebook/openbmc/tools/flashy/lib/utils"
-	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/image"
 )
 
 func init() {
@@ -43,7 +43,7 @@ func validateImagePartitions(stepParams step.StepParams) step.StepExitError {
 		return nil
 	}
 
-	err := validate.ValidateImageFile(stepParams.ImageFilePath)
+	err := image.ValidateImageFile(stepParams.ImageFilePath, stepParams.DeviceID)
 	if err != nil {
 		// the image could've been corrupted during copy,
 		// it is safe to reboot.

--- a/tools/flashy/flashy.go
+++ b/tools/flashy/flashy.go
@@ -30,14 +30,15 @@ import (
 	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/logger"
 	"github.com/facebook/openbmc/tools/flashy/lib/step"
-	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/image"
 )
 
 var (
 	// modes
 	installFlag = flag.Bool("install", false, "Install flashy")
 	checkImage  = flag.Bool("checkimage", false,
-		"Validate image partitions (`imagepath` must be specified). Available on non-OpenBMC systems.")
+		"Validate image partitions (`imagepath` must be specified). Available on non-OpenBMC systems. "+
+			"If `device` is specified the image file size will be validated against the size of the device.")
 	// step params
 	imageFilePath = flag.String("imagepath", "", "Path to image file")
 	deviceID      = flag.String("device", "", "Device ID (e.g. mtd:flash0)")
@@ -109,7 +110,7 @@ WARRANTIES OFF`)
 		log.Printf("Validating image...")
 		failIfFlagEmpty("imagepath", stepParams.ImageFilePath)
 
-		err := validate.ValidateImageFile(stepParams.ImageFilePath)
+		err := image.ValidateImageFile(stepParams.ImageFilePath, stepParams.DeviceID)
 		if err != nil {
 			log.Fatalf("Image '%v' failed validation: %v",
 				stepParams.ImageFilePath, err)

--- a/tools/flashy/lib/fileutils/fileutils.go
+++ b/tools/flashy/lib/fileutils/fileutils.go
@@ -296,3 +296,12 @@ var WriteFileWithTimeout = func(
 		return errors.Errorf("Timed out after '%v'", timeout)
 	}
 }
+
+// GetFileSize returns the file size (in bytes) for `filename`.
+var GetFileSize = func(filename string) (int64, error) {
+	fi, err := osStat(filename)
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}

--- a/tools/flashy/lib/validate/image/image.go
+++ b/tools/flashy/lib/validate/image/image.go
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2021-present Facebook. All Rights Reserved.
+ *
+ * This program file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in a file named COPYING; if not, write to the
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+package image
+
+import (
+	"log"
+	"syscall"
+
+	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
+	"github.com/facebook/openbmc/tools/flashy/lib/flash/flashutils"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/pkg/errors"
+)
+
+// validateImageFileSie ensures that the image file size is smaller than the size of the
+// flash device.
+// Precondition: deviceID is non-empty and is a valid deviceID.
+var validateImageFileSize = func(imageFilePath string, deviceID string) error {
+	imageSize, err := fileutils.GetFileSize(imageFilePath)
+	if err != nil {
+		return errors.Errorf("Unable to get size of image file '%v': %v",
+			imageFilePath, err)
+	}
+	flashDevice, err := flashutils.GetFlashDevice(deviceID)
+	if err != nil {
+		return errors.Errorf("Unable to get flash device from deviceID '%v': %v",
+			deviceID, err)
+	}
+	flashDeviceSize := flashDevice.GetFileSize()
+	if uint64(imageSize) > flashDeviceSize {
+		return errors.Errorf("Image size (%vB) larger than flash device size (%vB)",
+			imageSize, flashDeviceSize)
+	}
+	return nil
+}
+
+// ValidateImageFile takes in a path to an image file and runs
+// Validate over the data.
+// Takes in maybeDeviceI denoting a deviceID, which if non-empty is used to
+// get the flash device and ensure that the image file size is smaller than the size of the
+// flash device.
+var ValidateImageFile = func(imageFilePath string, maybeDeviceID string) error {
+	if len(maybeDeviceID) == 0 {
+		log.Printf("deviceID empty, bypassing image file size check.")
+	} else {
+		err := validateImageFileSize(imageFilePath, maybeDeviceID)
+		if err != nil {
+			return errors.Errorf("Image file size check failed: %v", err)
+		}
+	}
+	imageData, err := fileutils.MmapFile(imageFilePath,
+		syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		return errors.Errorf("Unable to read image file '%v': %v",
+			imageFilePath, err)
+	}
+	defer fileutils.Munmap(imageData)
+
+	return validate.Validate(imageData)
+}

--- a/tools/flashy/lib/validate/image/image_test.go
+++ b/tools/flashy/lib/validate/image/image_test.go
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2020-present Facebook. All Rights Reserved.
+ *
+ * This program file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in a file named COPYING; if not, write to the
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+package image
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
+	"github.com/facebook/openbmc/tools/flashy/lib/flash/flashutils"
+	"github.com/facebook/openbmc/tools/flashy/lib/flash/flashutils/devices"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/tests"
+	"github.com/pkg/errors"
+)
+
+func TestValidateImageFileSize(t *testing.T) {
+	getFileSizeOrig := fileutils.GetFileSize
+	getFlashDeviceOrig := flashutils.GetFlashDevice
+	defer func() {
+		fileutils.GetFileSize = getFileSizeOrig
+		flashutils.GetFlashDevice = getFlashDeviceOrig
+	}()
+
+	const mockImageFilePath = "/opt/flashy/image"
+	const mockDeviceID = "/dev/mtd5"
+
+	cases := []struct {
+		name           string
+		imSize         int64
+		imSizeErr      error
+		flashDevice    devices.FlashDevice
+		flashDeviceErr error
+		want           error
+	}{
+		{
+			name:   "Succeeded",
+			imSize: 32,
+			flashDevice: &devices.MemoryTechnologyDevice{
+				FileSize: 32,
+			},
+		},
+		{
+			name:   "Image file too large",
+			imSize: 34,
+			flashDevice: &devices.MemoryTechnologyDevice{
+				FileSize: 32,
+			},
+			want: errors.Errorf("Image size (34B) larger than flash device size (32B)"),
+		},
+		{
+			name:      "Failed to get imSize",
+			imSizeErr: errors.Errorf("failed"),
+			want:      errors.Errorf("Unable to get size of image file '/opt/flashy/image': failed"),
+		},
+		{
+			name:           "Failed to get flash device",
+			flashDeviceErr: errors.Errorf("failed"),
+			want:           errors.Errorf("Unable to get flash device from deviceID '/dev/mtd5': failed"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fileutils.GetFileSize = func(filename string) (int64, error) {
+				if filename != mockImageFilePath {
+					t.Errorf("filename: want '%v' got '%v'", mockImageFilePath, filename)
+				}
+				return tc.imSize, tc.imSizeErr
+			}
+			flashutils.GetFlashDevice = func(deviceID string) (devices.FlashDevice, error) {
+				if deviceID != mockDeviceID {
+					t.Errorf("deviceID: want '%v' got '%v'", mockDeviceID, deviceID)
+				}
+				return tc.flashDevice, tc.flashDeviceErr
+			}
+			got := validateImageFileSize(mockImageFilePath, mockDeviceID)
+			tests.CompareTestErrors(tc.want, got, t)
+		})
+	}
+}
+
+func TestValidateImageFile(t *testing.T) {
+	validateImageFileSizeOrig := validateImageFileSize
+	mmapFileOrig := fileutils.MmapFile
+	validateOrig := validate.Validate
+	getFileSizeOrig := fileutils.GetFileSize
+	defer func() {
+		validateImageFileSize = validateImageFileSizeOrig
+		fileutils.MmapFile = mmapFileOrig
+		validate.Validate = validateOrig
+		fileutils.GetFileSize = getFileSizeOrig
+	}()
+
+	const imageFileName = "/opt/upgrade/image"
+	imageData := []byte("abcd")
+
+	cases := []struct {
+		name          string
+		maybeDeviceID string
+		imSizeErr     error
+		mmapErr       error
+		validateErr   error
+		want          error
+	}{
+		{
+			name:        "succeeded",
+			mmapErr:     nil,
+			validateErr: nil,
+			want:        nil,
+		},
+		{
+			name:        "mmap error",
+			mmapErr:     errors.Errorf("mmap error"),
+			validateErr: nil,
+			want: errors.Errorf("Unable to read image file '%v': %v",
+				"/opt/upgrade/image", "mmap error"),
+		},
+		{
+			name:        "validation error",
+			mmapErr:     nil,
+			validateErr: errors.Errorf("validation failed"),
+			want:        errors.Errorf("validation failed"),
+		},
+		{
+			name:      "file size not called because maybeDeviceID is empty",
+			imSizeErr: errors.Errorf("Should not be called"),
+		},
+		{
+			name:          "file size error",
+			maybeDeviceID: "mtd:flash0",
+			imSizeErr:     errors.Errorf("Failed"),
+			want:          errors.Errorf("Image file size check failed: Failed"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			validateImageFileSize = func(imageFilePath string, deviceID string) error {
+				if imageFilePath != imageFileName {
+					t.Errorf("imageFilePath: want '%v' got '%v'", imageFilePath, imageFileName)
+				}
+				if deviceID != tc.maybeDeviceID {
+					t.Errorf("deviceID: want '%v' got '%v'", tc.maybeDeviceID, deviceID)
+				}
+				return tc.imSizeErr
+			}
+			fileutils.MmapFile = func(filename string, prot, flags int) ([]byte, error) {
+				if filename != imageFileName {
+					t.Errorf("filename: want '%v' got '%v'", imageFileName, filename)
+				}
+				return imageData, tc.mmapErr
+			}
+			validate.Validate = func(data []byte) error {
+				if !bytes.Equal(data, imageData) {
+					t.Errorf("data: want '%v' got '%v'", imageData, data)
+				}
+				return tc.validateErr
+			}
+
+			got := ValidateImageFile(imageFileName, tc.maybeDeviceID)
+			tests.CompareTestErrors(tc.want, got, t)
+		})
+	}
+}

--- a/tools/flashy/lib/validate/validate.go
+++ b/tools/flashy/lib/validate/validate.go
@@ -21,9 +21,7 @@ package validate
 
 import (
 	"log"
-	"syscall"
 
-	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 	"github.com/pkg/errors"
 )
@@ -56,18 +54,4 @@ var Validate = func(data []byte) error {
 	errMsg := "*** FAILED: Validation failed ***"
 	log.Print(errMsg)
 	return errors.Errorf(errMsg)
-}
-
-// ValidateImageFile takes in a path to an image file and runs
-// Validate over the data.
-var ValidateImageFile = func(imageFilePath string) error {
-	imageData, err := fileutils.MmapFile(imageFilePath,
-		syscall.PROT_READ, syscall.MAP_SHARED)
-	if err != nil {
-		return errors.Errorf("Unable to read image file '%v': %v",
-			imageFilePath, err)
-	}
-	defer fileutils.Munmap(imageData)
-
-	return Validate(imageData)
 }

--- a/tools/flashy/utilities/check-image.go
+++ b/tools/flashy/utilities/check-image.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/facebook/openbmc/tools/flashy/lib/step"
-	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/image"
 )
 
 func init() {
@@ -37,17 +37,23 @@ func checkImageUsage() {
 -----------
 Validates partitions in an image.
 
-Usage: check-image FILE
+Usage: check-image FILE DEVICE_ID
+
+DEVICE_ID is optional and denotes the target flash device ID (e.g. mtd:flash0), which is used
+to ensure that the image file size is smaller than that of the target flash device.
 `)
 }
 
 func checkImage(args []string) error {
-	if len(args) != 2 || len(args) > 1 && (strings.Contains(args[1], "help") || args[1] == "-h") {
+	if len(args) < 2 || len(args) > 3 || len(args) > 1 && (strings.Contains(args[1], "help") || args[1] == "-h") {
 		checkImageUsage()
 		return nil
 	}
 
 	imageFilePath := args[1]
-
-	return validate.ValidateImageFile(imageFilePath)
+	maybeDeviceID := ""
+	if len(args) == 3 {
+		maybeDeviceID = args[2]
+	}
+	return image.ValidateImageFile(imageFilePath, maybeDeviceID)
 }


### PR DESCRIPTION
# Summary

As title. Corresponds to `fw-util` in https://github.com/facebook/openbmc/commit/f137c9abc78630971d95c589641e196a11c9584f

The difference is that the image file size is validated against the target flash device's size, if the flash target device ID is provided (it is optional during `./flashy -checkimage` or the `check-image` utility, during which the image file size check is bypassed. This is to support validating images on dev servers,)

## Test plan
Unit tests (`go test ./...`)