### PR TITLE
flashy: Support getting ImageFormats via buildname and add `grandcanyon` image formats

### DIFF
--- a/tools/flashy/lib/validate/validate.go
+++ b/tools/flashy/lib/validate/validate.go
@@ -28,12 +28,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Validate tries to validate partitions according to all configs defined in
-// partition.ImageFormats. If one succeeds, return nil. If none succeeds,
+// Validate tries to validate partitions according to all configs acquired from
+// partition.GetImageFormats.
+// If one succeeds, return nil. If none succeeds,
 // validation has failed, return the error.
-// Supports both data from image file and flash device
+// Supports both data from image file and flash device.
 var Validate = func(data []byte) error {
-	for _, imageFormat := range partition.ImageFormats {
+	for _, imageFormat := range partition.GetImageFormats() {
 		log.Printf("*** Attempting to validate using image format '%v' ***",
 			imageFormat.Name)
 

--- a/tools/flashy/lib/validate/validate_test.go
+++ b/tools/flashy/lib/validate/validate_test.go
@@ -32,10 +32,10 @@ import (
 
 func TestValidate(t *testing.T) {
 	// mock and defer restore ImageFormats, ValidatePartitionsFromPartitionConfigs
-	imageFormatsOrig := partition.ImageFormats
+	getImageFormatsOrig := partition.GetImageFormats
 	validatePartitionsFromPartitionConfigsOrig := partition.ValidatePartitionsFromPartitionConfigs
 	defer func() {
-		partition.ImageFormats = imageFormatsOrig
+		partition.GetImageFormats = getImageFormatsOrig
 		partition.ValidatePartitionsFromPartitionConfigs = validatePartitionsFromPartitionConfigsOrig
 	}()
 
@@ -92,7 +92,9 @@ func TestValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			exampleData := []byte("abcd")
 			i := 0
-			partition.ImageFormats = tc.imageFormats
+			partition.GetImageFormats = func() []partition.ImageFormat {
+				return tc.imageFormats
+			}
 			partition.ValidatePartitionsFromPartitionConfigs = func(
 				data []byte,
 				partitionConfigs []partition.PartitionConfigInfo,


### PR DESCRIPTION
# Summary

Corresponding diff in `fw-util`: https://github.com/facebook/openbmc/commit/bc32863c97e396e41a9c2054d2e2806562632310

Previously flashy was not able to acquire platform-specific image formats that are used to validate images/devices. This diff introduces a feature in which the ImageFormats to validate against are obtained via the buildname from `/etc/issue`.

This feature is required as `grandcanyon` is retrofitted to vboot as in https://github.com/facebook/openbmc/commit/bc32863c97e396e41a9c2054d2e2806562632310

## Test plan
Unit tests `go test ./...`
Please help run validation tests as per https://github.com/facebook/openbmc/commit/bc32863c97e396e41a9c2054d2e2806562632310
```bash
/opt/flashy -checkimage -imagepath <IMAGE>
```