### PR TITLE
flashy: Use safe `BytesSliceRange` for safe slicing

### DIFF
--- a/tools/flashy/lib/flash/flashcp/flashcp_test.go
+++ b/tools/flashy/lib/flash/flashcp/flashcp_test.go
@@ -598,6 +598,12 @@ func TestFlashImage(t *testing.T) {
 			writeErr: nil,
 			want:     nil,
 		},
+		{
+			name:     "roOffset too large",
+			roOffset: 100,
+			writeErr: nil,
+			want:     errors.Errorf("Unable to get image data after roOffset (100): Slice start (100) > end (6)"),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -697,6 +703,14 @@ func TestVerifyFlash(t *testing.T) {
 			deviceData:     []byte("XXXXar"),
 			mmapErr:        nil,
 			want:           nil,
+		},
+		{
+			name:           "roOffset too large",
+			roOffset:       100,
+			deviceFileName: "/dev/mtd42",
+			deviceData:     imData,
+			mmapErr:        nil,
+			want:           errors.Errorf("Unable to get image data after roOffset (100): Slice start (100) > end (6)"),
 		},
 	}
 

--- a/tools/flashy/lib/utils/helper.go
+++ b/tools/flashy/lib/utils/helper.go
@@ -248,11 +248,11 @@ func GetWord(data []byte, offset uint32) (uint32, error) {
 	if err != nil {
 		return 0, errors.Errorf("Failed to get end of offset: %v", err)
 	}
-	if endOffset > uint32(len(data)) {
-		return 0, errors.Errorf("Required offset %v out of range of data size %v",
-			offset, len(data))
+	wordBytes, err := BytesSliceRange(data, offset, endOffset)
+	if err != nil {
+		return 0, errors.Errorf("Failed to get bytes for word: %v", err)
 	}
-	val := binary.BigEndian.Uint32(data[offset:endOffset])
+	val := binary.BigEndian.Uint32(wordBytes)
 	return val, nil
 }
 

--- a/tools/flashy/lib/utils/helper_test.go
+++ b/tools/flashy/lib/utils/helper_test.go
@@ -485,12 +485,11 @@ func TestGetWord(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:   "out of range",
-			data:   []byte{0x01, 0x02, 0x03, 0x04},
-			offset: 2,
-			want:   0,
-			wantErr: errors.Errorf("Required offset %v out of range of data size %v",
-				2, 4),
+			name:    "out of range",
+			data:    []byte{0x01, 0x02, 0x03, 0x04},
+			offset:  2,
+			want:    0,
+			wantErr: errors.Errorf("Failed to get bytes for word: Slice end (6) larger than original slice length (4)"),
 		},
 		{
 			name:    "overflowed",

--- a/tools/flashy/lib/utils/slice.go
+++ b/tools/flashy/lib/utils/slice.go
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2021-present Facebook. All Rights Reserved.
+ *
+ * This program file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in a file named COPYING; if not, write to the
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+package utils
+
+import (
+	"github.com/pkg/errors"
+)
+
+// BytesSliceRange returns s[start:end] but with bounds checks
+func BytesSliceRange(s []byte, start, end uint32) ([]byte, error) {
+	if start > end {
+		return nil, errors.Errorf("Slice start (%v) > end (%v)", start, end)
+	}
+	if end > uint32(len(s)) {
+		return nil, errors.Errorf("Slice end (%v) larger than original slice length (%v)", end, len(s))
+	}
+	return s[start:end], nil
+}

--- a/tools/flashy/lib/utils/slice_test.go
+++ b/tools/flashy/lib/utils/slice_test.go
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2021-present Facebook. All Rights Reserved.
+ *
+ * This program file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in a file named COPYING; if not, write to the
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+package utils
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/facebook/openbmc/tools/flashy/tests"
+	"github.com/pkg/errors"
+)
+
+func TestByteSliceRange(t *testing.T) {
+	sampleS := []byte{1, 2, 3, 4, 5, 6, 7}
+	cases := []struct {
+		name    string
+		s       []byte
+		start   uint32
+		end     uint32
+		want    []byte
+		wantErr error
+	}{
+		{
+			name:    "OK",
+			s:       sampleS,
+			start:   3,
+			end:     5,
+			want:    sampleS[3:5],
+			wantErr: nil,
+		},
+		{
+			name:    "start > end",
+			s:       sampleS,
+			start:   3,
+			end:     1,
+			want:    nil,
+			wantErr: errors.Errorf("Slice start (3) > end (1)"),
+		},
+		{
+			name:    "end too large",
+			s:       sampleS,
+			start:   3,
+			end:     10000,
+			want:    nil,
+			wantErr: errors.Errorf("Slice end (10000) larger than original slice length (7)"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := BytesSliceRange(tc.s, tc.start, tc.end)
+			tests.CompareTestErrors(tc.wantErr, err, t)
+			if !bytes.Equal(tc.want, got) {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
+		})
+	}
+}

--- a/tools/flashy/lib/utils/vboot.go
+++ b/tools/flashy/lib/utils/vboot.go
@@ -151,7 +151,10 @@ var GetVbs = func() (Vbs, error) {
 	if err != nil {
 		return vbs, errors.Errorf("VBS end offset overflowed: %v", err)
 	}
-	vbsData := pageData[dataOffset:vbsEndOffset]
+	vbsData, err := BytesSliceRange(pageData, dataOffset, vbsEndOffset)
+	if err != nil {
+		return vbs, errors.Errorf("Failed to get vbs data: %v", err)
+	}
 
 	return decodeVbs(vbsData)
 }

--- a/tools/flashy/lib/validate/partition/p_fbmeta.go
+++ b/tools/flashy/lib/validate/partition/p_fbmeta.go
@@ -141,13 +141,16 @@ func (p *FBMetaImagePartition) GetType() PartitionConfigType {
 // from the meta partition
 func (p *FBMetaImagePartition) getMetaInfo() (FBMetaInfo, error) {
 	var metaInfo FBMetaInfo
-	offsetEnd := fbmetaImageMetaPartitionSize + fbmetaImageMetaPartitionOffset
-	if uint32(offsetEnd) > p.GetSize() {
+	offsetEnd := uint32(fbmetaImageMetaPartitionSize + fbmetaImageMetaPartitionOffset)
+	if offsetEnd > p.GetSize() {
 		return metaInfo, errors.Errorf("Image/device size too small (%v B) to contain meta partition region",
 			p.GetSize())
 	}
 
-	metaPartitionData := p.Data[fbmetaImageMetaPartitionOffset:offsetEnd]
+	metaPartitionData, err := utils.BytesSliceRange(p.Data, fbmetaImageMetaPartitionOffset, offsetEnd)
+	if err != nil {
+		return metaInfo, errors.Errorf("Unable to get meta partition data: %v", err)
+	}
 
 	return parseAndValidateFBImageMetaJSON(metaPartitionData)
 }

--- a/tools/flashy/lib/validate/partition/p_fit.go
+++ b/tools/flashy/lib/validate/partition/p_fit.go
@@ -215,7 +215,7 @@ func (p *FitPartition) getDataFromImageNodeViaDataLink(imageNode *dt.Node) ([]by
 			"too large for partition size (%v)", endOffset, dataSize, dataPos, p.GetSize())
 	}
 
-	return p.Data[dataPos:endOffset], nil
+	return utils.BytesSliceRange(p.Data, dataPos, endOffset)
 }
 
 // given the image node, get the sha256 checksum.

--- a/tools/flashy/lib/validate/partition/p_legacy_uboot.go
+++ b/tools/flashy/lib/validate/partition/p_legacy_uboot.go
@@ -132,9 +132,12 @@ func (p *LegacyUbootPartition) checkData() error {
 		return errors.Errorf("Legacy U-Boot partition incomplete, data part too small.")
 	}
 
-	calcDataChecksum := crc32.ChecksumIEEE(
-		p.Data[legacyUbootHeaderSize:imageDataEnd],
-	)
+	imageDataWithoutUbootHeader, err := utils.BytesSliceRange(p.Data, legacyUbootHeaderSize, imageDataEnd)
+	if err != nil {
+		return err
+	}
+
+	calcDataChecksum := crc32.ChecksumIEEE(imageDataWithoutUbootHeader)
 	if calcDataChecksum != p.header.Ih_dcrc {
 		return errors.Errorf("Calculated legacy U-Boot data checksum 0x%X does not match checksum in header 0x%X",
 			calcDataChecksum, p.header.Ih_dcrc)

--- a/tools/flashy/lib/validate/partition/validate.go
+++ b/tools/flashy/lib/validate/partition/validate.go
@@ -95,7 +95,10 @@ var getAllPartitionsFromPartitionConfigs = func(
 		}
 
 		// only pass in region of data defined as the partition
-		pData := data[pInfo.Offset:pOffsetEnd]
+		pData, err := utils.BytesSliceRange(data, pInfo.Offset, pOffsetEnd)
+		if err != nil {
+			return nil, errors.Errorf("Unable to extract partition data: %v", err)
+		}
 		args := PartitionFactoryArgs{
 			Data:  pData,
 			PInfo: pInfo,


### PR DESCRIPTION
# Summary
Out-of-bounds slicing in Golang is panicky, and manually checking before slicing is tedious. Use a dedicated function with bounds checks for all bytes slicing.

No functional changes are made

## Test plan
Unit tests `go test ./...`

testhard