### PR TITLE
flashy: Add imageFormats as an argument to Validate

### DIFF
--- a/tools/flashy/lib/flash/flashutils/devices/mtd.go
+++ b/tools/flashy/lib/flash/flashutils/devices/mtd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/utils"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 	"github.com/pkg/errors"
 )
 
@@ -100,7 +101,7 @@ func (m *MemoryTechnologyDevice) Validate() error {
 		return errors.Errorf("Can't mmap flash device: %v", err)
 	}
 	defer m.Munmap(data)
-	return validate.Validate(data)
+	return validate.Validate(data, partition.ImageFormats)
 }
 
 // GetMTDBlockFilePath gets the /dev/mtdblock[0-9]+ file path

--- a/tools/flashy/lib/flash/flashutils/devices/mtd_test.go
+++ b/tools/flashy/lib/flash/flashutils/devices/mtd_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 	"github.com/facebook/openbmc/tools/flashy/tests"
 	"github.com/pkg/errors"
 )
@@ -294,7 +295,7 @@ func TestValidate(t *testing.T) {
 				munmapCalled = true
 				return nil
 			}
-			validate.Validate = func(data []byte) error {
+			validate.Validate = func(data []byte, imageFormats []partition.ImageFormat) error {
 				if !reflect.DeepEqual(exampleData, data) {
 					t.Errorf("data: want '%v' got '%v'", exampleData, data)
 				}

--- a/tools/flashy/lib/validate/image/image.go
+++ b/tools/flashy/lib/validate/image/image.go
@@ -26,6 +26,7 @@ import (
 	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/flash/flashutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 	"github.com/pkg/errors"
 )
 
@@ -73,5 +74,5 @@ var ValidateImageFile = func(imageFilePath string, maybeDeviceID string) error {
 	}
 	defer fileutils.Munmap(imageData)
 
-	return validate.Validate(imageData)
+	return validate.Validate(imageData, partition.ImageFormats)
 }

--- a/tools/flashy/lib/validate/image/image_test.go
+++ b/tools/flashy/lib/validate/image/image_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/facebook/openbmc/tools/flashy/lib/flash/flashutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/flash/flashutils/devices"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 	"github.com/facebook/openbmc/tools/flashy/tests"
 	"github.com/pkg/errors"
 )
@@ -166,7 +167,7 @@ func TestValidateImageFile(t *testing.T) {
 				}
 				return imageData, tc.mmapErr
 			}
-			validate.Validate = func(data []byte) error {
+			validate.Validate = func(data []byte, imageFormats []partition.ImageFormat) error {
 				if !bytes.Equal(data, imageData) {
 					t.Errorf("data: want '%v' got '%v'", imageData, data)
 				}

--- a/tools/flashy/lib/validate/validate.go
+++ b/tools/flashy/lib/validate/validate.go
@@ -27,11 +27,11 @@ import (
 )
 
 // Validate tries to validate partitions according to all configs defined in
-// partition.ImageFormats. If one succeeds, return nil. If none succeeds,
+// imageFormats. If one succeeds, return nil. If none succeeds,
 // validation has failed, return the error.
 // Supports both data from image file and flash device
-var Validate = func(data []byte) error {
-	for _, imageFormat := range partition.ImageFormats {
+var Validate = func(data []byte, imageFormats []partition.ImageFormat) error {
+	for _, imageFormat := range imageFormats {
 		log.Printf("*** Attempting to validate using image format '%v' ***",
 			imageFormat.Name)
 

--- a/tools/flashy/lib/validate/validate_test.go
+++ b/tools/flashy/lib/validate/validate_test.go
@@ -29,11 +29,9 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	// mock and defer restore ImageFormats, ValidatePartitionsFromPartitionConfigs
-	imageFormatsOrig := partition.ImageFormats
+	// mock and defer restore ValidatePartitionsFromPartitionConfigs
 	validatePartitionsFromPartitionConfigsOrig := partition.ValidatePartitionsFromPartitionConfigs
 	defer func() {
-		partition.ImageFormats = imageFormatsOrig
 		partition.ValidatePartitionsFromPartitionConfigs = validatePartitionsFromPartitionConfigsOrig
 	}()
 
@@ -90,7 +88,6 @@ func TestValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			exampleData := []byte("abcd")
 			i := 0
-			partition.ImageFormats = tc.imageFormats
 			partition.ValidatePartitionsFromPartitionConfigs = func(
 				data []byte,
 				partitionConfigs []partition.PartitionConfigInfo,
@@ -104,7 +101,7 @@ func TestValidate(t *testing.T) {
 				return tc.validatePartitionsErrs[idx]
 			}
 
-			got := Validate(exampleData)
+			got := Validate(exampleData, tc.imageFormats)
 			tests.CompareTestErrors(tc.want, got, t)
 		})
 	}


### PR DESCRIPTION
# Summary

Take in a slice of valid `imageFormats` to `Validate`--this is to facilitate platform-specific valid imageFormats via platform-specific steps in the future.

## Test plan

Unit tests pass