### PR TITLE
flashy: Support `grandcanyon` image meta validation

### DIFF
--- a/tools/flashy/checks_and_remediations/common/41_validate_image_partitions.go
+++ b/tools/flashy/checks_and_remediations/common/41_validate_image_partitions.go
@@ -25,6 +25,7 @@ import (
 	"github.com/facebook/openbmc/tools/flashy/lib/step"
 	"github.com/facebook/openbmc/tools/flashy/lib/utils"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate/image"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 )
 
 func init() {
@@ -43,7 +44,11 @@ func validateImagePartitions(stepParams step.StepParams) step.StepExitError {
 		return nil
 	}
 
-	err := image.ValidateImageFile(stepParams.ImageFilePath, stepParams.DeviceID)
+	err := image.ValidateImageFile(
+		stepParams.ImageFilePath,
+		stepParams.DeviceID,
+		partition.ImageFormats,
+	)
 	if err != nil {
 		// the image could've been corrupted during copy,
 		// it is safe to reboot.

--- a/tools/flashy/checks_and_remediations/common/41_validate_image_partitions_test.go
+++ b/tools/flashy/checks_and_remediations/common/41_validate_image_partitions_test.go
@@ -20,11 +20,13 @@
 package common
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/facebook/openbmc/tools/flashy/lib/step"
 	"github.com/facebook/openbmc/tools/flashy/lib/utils"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate/image"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 	"github.com/pkg/errors"
 )
 
@@ -82,13 +84,16 @@ func TestValidateImagePartitions(t *testing.T) {
 			utils.IsPfrSystem = func() bool {
 				return tc.isPfrSystem
 			}
-			image.ValidateImageFile = func(imageFilePath string, deviceID string) error {
+			image.ValidateImageFile = func(imageFilePath string, deviceID string, imageFormats []partition.ImageFormat) error {
 				if imageFilePath != imageFileName {
 					t.Errorf("Image filename: want '%v' got '%v'",
 						imageFileName, imageFilePath)
 				}
 				if deviceID != mockDeviceID {
 					t.Errorf("deviceID: want '%v' got '%v'", mockDeviceID, deviceID)
+				}
+				if !reflect.DeepEqual(imageFormats, partition.ImageFormats) {
+					t.Errorf("imageFormats: want '%v' got '%v'", partition.ImageFormats, imageFormats)
 				}
 				return tc.validateError
 			}

--- a/tools/flashy/checks_and_remediations/grandcanyon/00_validate_image_meta_partitions.go
+++ b/tools/flashy/checks_and_remediations/grandcanyon/00_validate_image_meta_partitions.go
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2021-present Facebook. All Rights Reserved.
+ *
+ * This program file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in a file named COPYING; if not, write to the
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+package remediations_grandcanyon
+
+import (
+	"log"
+
+	"github.com/facebook/openbmc/tools/flashy/lib/step"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/image"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
+)
+
+func init() {
+	step.RegisterStep(validateImageMetaPartitions)
+}
+
+// validateMetaPartitions validates the image file against the meta partition format.
+// This is for platforms that are to be retrofitted to vboot/fit and will block
+// flashes that go back to now unsupported formats.
+// Note that checks_and_remediations/common/41_validate_image_partitions will already have
+// validated the image, but this step is more strict. It is worth the extra check here.
+func validateImageMetaPartitions(stepParams step.StepParams) step.StepExitError {
+	if stepParams.Clowntown {
+		log.Printf("===== WARNING: Clowntown mode: Bypassing image partition validation =====")
+		log.Printf("===== THERE IS RISK OF BRICKING THIS DEVICE =====")
+		return nil
+	}
+
+	// wrap into a slice
+	imageFormats := []partition.ImageFormat{partition.MetaPartitionImageFormat}
+
+	err := image.ValidateImageFile(
+		stepParams.ImageFilePath,
+		stepParams.DeviceID,
+		imageFormats,
+	)
+	if err != nil {
+		// the image could've been corrupted during copy,
+		// it is safe to reboot.
+		return step.ExitSafeToReboot{Err: err}
+	}
+	return nil
+}

--- a/tools/flashy/checks_and_remediations/grandcanyon/00_validate_image_meta_partitions_test.go
+++ b/tools/flashy/checks_and_remediations/grandcanyon/00_validate_image_meta_partitions_test.go
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2021-present Facebook. All Rights Reserved.
+ *
+ * This program file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in a file named COPYING; if not, write to the
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+package remediations_grandcanyon
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/facebook/openbmc/tools/flashy/lib/step"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/image"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
+	"github.com/pkg/errors"
+)
+
+func TestValidateImageMetaPartitions(t *testing.T) {
+	validateImageFileOrig := image.ValidateImageFile
+	defer func() {
+		image.ValidateImageFile = validateImageFileOrig
+	}()
+
+	cases := []struct {
+		name          string
+		clowntown     bool
+		validateError error
+		want          step.StepExitError
+	}{
+		{
+			name:          "successful validation",
+			clowntown:     false,
+			validateError: nil,
+			want:          nil,
+		},
+		{
+			name:          "validation failed",
+			clowntown:     false,
+			validateError: errors.Errorf("validation failed"),
+			want: step.ExitSafeToReboot{
+				Err: errors.Errorf("validation failed"),
+			},
+		},
+		{
+			name:          "clowntown bypass",
+			clowntown:     true,
+			validateError: errors.Errorf("validation failed"),
+			want:          nil,
+		},
+	}
+	const mockDeviceID = "mtd:flashmock"
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			imageFileName := "/opt/upgrade/image"
+			image.ValidateImageFile = func(imageFilePath string, deviceID string, imageFormats []partition.ImageFormat) error {
+				if imageFilePath != imageFileName {
+					t.Errorf("Image filename: want '%v' got '%v'",
+						imageFileName, imageFilePath)
+				}
+				if deviceID != mockDeviceID {
+					t.Errorf("deviceID: want '%v' got '%v'", mockDeviceID, deviceID)
+				}
+				if !reflect.DeepEqual(imageFormats, []partition.ImageFormat{partition.MetaPartitionImageFormat}) {
+					t.Errorf("imageFormats: want '%v' got '%v'",
+						[]partition.ImageFormat{partition.MetaPartitionImageFormat},
+						imageFormats)
+				}
+				return tc.validateError
+			}
+			stepParams := step.StepParams{
+				Clowntown:     tc.clowntown,
+				ImageFilePath: imageFileName,
+				DeviceID:      mockDeviceID,
+			}
+
+			got := validateImageMetaPartitions(stepParams)
+
+			step.CompareTestExitErrors(tc.want, got, t)
+		})
+	}
+}

--- a/tools/flashy/flashy.go
+++ b/tools/flashy/flashy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/facebook/openbmc/tools/flashy/lib/logger"
 	"github.com/facebook/openbmc/tools/flashy/lib/step"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate/image"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 )
 
 var (
@@ -38,7 +39,8 @@ var (
 	installFlag = flag.Bool("install", false, "Install flashy")
 	checkImage  = flag.Bool("checkimage", false,
 		"Validate image partitions (`imagepath` must be specified). Available on non-OpenBMC systems. "+
-			"If `device` is specified the image file size will be validated against the size of the device.")
+			"If `device` is specified the image file size will be validated against the size of the device. "+
+			"Note that validation here checks against all known valid image formats.")
 	// step params
 	imageFilePath = flag.String("imagepath", "", "Path to image file")
 	deviceID      = flag.String("device", "", "Device ID (e.g. mtd:flash0)")
@@ -110,7 +112,11 @@ WARRANTIES OFF`)
 		log.Printf("Validating image...")
 		failIfFlagEmpty("imagepath", stepParams.ImageFilePath)
 
-		err := image.ValidateImageFile(stepParams.ImageFilePath, stepParams.DeviceID)
+		err := image.ValidateImageFile(
+			stepParams.ImageFilePath,
+			stepParams.DeviceID,
+			partition.ImageFormats,
+		)
 		if err != nil {
 			log.Fatalf("Image '%v' failed validation: %v",
 				stepParams.ImageFilePath, err)

--- a/tools/flashy/install/install.go
+++ b/tools/flashy/install/install.go
@@ -31,9 +31,10 @@ import (
 	// all packages containing steps must be included to successfully run install
 	_ "github.com/facebook/openbmc/tools/flashy/checks_and_remediations/common"
 	_ "github.com/facebook/openbmc/tools/flashy/checks_and_remediations/galaxy100"
+	_ "github.com/facebook/openbmc/tools/flashy/checks_and_remediations/grandcanyon"
+	_ "github.com/facebook/openbmc/tools/flashy/checks_and_remediations/minipack"
 	_ "github.com/facebook/openbmc/tools/flashy/checks_and_remediations/wedge100"
 	_ "github.com/facebook/openbmc/tools/flashy/checks_and_remediations/yamp"
-	_ "github.com/facebook/openbmc/tools/flashy/checks_and_remediations/minipack"
 	_ "github.com/facebook/openbmc/tools/flashy/flash_procedure"
 	_ "github.com/facebook/openbmc/tools/flashy/utilities"
 )

--- a/tools/flashy/lib/flash/flashutils/devices/mtd.go
+++ b/tools/flashy/lib/flash/flashutils/devices/mtd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/utils"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 	"github.com/pkg/errors"
 )
 
@@ -100,7 +101,7 @@ func (m *MemoryTechnologyDevice) Validate() error {
 		return errors.Errorf("Can't mmap flash device: %v", err)
 	}
 	defer m.Munmap(data)
-	return validate.Validate(data)
+	return validate.Validate(data, partition.ImageFormats)
 }
 
 // GetMTDBlockFilePath gets the /dev/mtdblock[0-9]+ file path

--- a/tools/flashy/lib/flash/flashutils/devices/mtd_test.go
+++ b/tools/flashy/lib/flash/flashutils/devices/mtd_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 	"github.com/facebook/openbmc/tools/flashy/tests"
 	"github.com/pkg/errors"
 )
@@ -294,7 +295,7 @@ func TestValidate(t *testing.T) {
 				munmapCalled = true
 				return nil
 			}
-			validate.Validate = func(data []byte) error {
+			validate.Validate = func(data []byte, imageFormats []partition.ImageFormat) error {
 				if !reflect.DeepEqual(exampleData, data) {
 					t.Errorf("data: want '%v' got '%v'", exampleData, data)
 				}

--- a/tools/flashy/lib/validate/image/image.go
+++ b/tools/flashy/lib/validate/image/image.go
@@ -26,6 +26,7 @@ import (
 	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/flash/flashutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 	"github.com/pkg/errors"
 )
 
@@ -73,5 +74,5 @@ var ValidateImageFile = func(imageFilePath string, maybeDeviceID string) error {
 	}
 	defer fileutils.Munmap(imageData)
 
-	return validate.Validate(imageData)
+	return validate.Validate(imageData, partition.ImageFormats)
 }

--- a/tools/flashy/lib/validate/image/image.go
+++ b/tools/flashy/lib/validate/image/image.go
@@ -54,10 +54,15 @@ var validateImageFileSize = func(imageFilePath string, deviceID string) error {
 
 // ValidateImageFile takes in a path to an image file and runs
 // Validate over the data.
-// Takes in maybeDeviceI denoting a deviceID, which if non-empty is used to
+// Takes in maybeDeviceID denoting a deviceID, which if non-empty is used to
 // get the flash device and ensure that the image file size is smaller than the size of the
 // flash device.
-var ValidateImageFile = func(imageFilePath string, maybeDeviceID string) error {
+// Also takes in a list of imageFormats to validate the image against.
+var ValidateImageFile = func(
+	imageFilePath string,
+	maybeDeviceID string,
+	imageFormats []partition.ImageFormat,
+) error {
 	if len(maybeDeviceID) == 0 {
 		log.Printf("deviceID empty, bypassing image file size check.")
 	} else {
@@ -74,5 +79,5 @@ var ValidateImageFile = func(imageFilePath string, maybeDeviceID string) error {
 	}
 	defer fileutils.Munmap(imageData)
 
-	return validate.Validate(imageData, partition.ImageFormats)
+	return validate.Validate(imageData, imageFormats)
 }

--- a/tools/flashy/lib/validate/image/image_test.go
+++ b/tools/flashy/lib/validate/image/image_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/facebook/openbmc/tools/flashy/lib/flash/flashutils"
 	"github.com/facebook/openbmc/tools/flashy/lib/flash/flashutils/devices"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 	"github.com/facebook/openbmc/tools/flashy/tests"
 	"github.com/pkg/errors"
 )
@@ -166,7 +167,7 @@ func TestValidateImageFile(t *testing.T) {
 				}
 				return imageData, tc.mmapErr
 			}
-			validate.Validate = func(data []byte) error {
+			validate.Validate = func(data []byte, imageFormats []partition.ImageFormat) error {
 				if !bytes.Equal(data, imageData) {
 					t.Errorf("data: want '%v' got '%v'", imageData, data)
 				}

--- a/tools/flashy/lib/validate/image/image_test.go
+++ b/tools/flashy/lib/validate/image/image_test.go
@@ -21,6 +21,7 @@ package image
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/facebook/openbmc/tools/flashy/lib/fileutils"
@@ -171,10 +172,13 @@ func TestValidateImageFile(t *testing.T) {
 				if !bytes.Equal(data, imageData) {
 					t.Errorf("data: want '%v' got '%v'", imageData, data)
 				}
+				if !reflect.DeepEqual(imageFormats, partition.ImageFormats) {
+					t.Errorf("imageFormats: want '%v' got '%v'", partition.ImageFormats, imageFormats)
+				}
 				return tc.validateErr
 			}
 
-			got := ValidateImageFile(imageFileName, tc.maybeDeviceID)
+			got := ValidateImageFile(imageFileName, tc.maybeDeviceID, partition.ImageFormats)
 			tests.CompareTestErrors(tc.want, got, t)
 		})
 	}

--- a/tools/flashy/lib/validate/partition/config.go
+++ b/tools/flashy/lib/validate/partition/config.go
@@ -50,6 +50,23 @@ type PartitionConfigInfo struct {
 	Checksum string
 }
 
+// MetaPartitionImageFormat covers both vboot- and fit-meta image formats.
+// This image format is exported to allow platform-specific image validations for
+// retrofitting purposes (therefore disallowing upgrades to now-unsupported image formats).
+var MetaPartitionImageFormat = ImageFormat{
+	Name: "meta",
+	PartitionConfigs: []PartitionConfigInfo{
+		{
+			// pass in the whole image and let MetaImagePartition deal with
+			// finding the partitionConfigs and checksums
+			Name:   "fbmeta-image",
+			Offset: 0,
+			Size:   32 * 1024 * 1024,
+			Type:   FBMETA_IMAGE,
+		},
+	},
+}
+
 // ImageFormats is taken from fw-util (common/recipes-core/fw-util/files/image_parts.json).
 // It maps from image format name to a array of partition configurations.
 // The idea is that the image is validated against every single format type
@@ -63,20 +80,7 @@ type PartitionConfigInfo struct {
 // (4) vboot spl+recovery can be treated as UBOOT. It will be ignored if the flash1
 //     header is RO (e.g. fbtp)
 var ImageFormats = []ImageFormat{
-	{
-		// covers both vboot-meta and fit-meta
-		Name: "meta",
-		PartitionConfigs: []PartitionConfigInfo{
-			{
-				// pass in the whole image and let MetaImagePartition deal with
-				// finding the partitionConfigs and checksums
-				Name:   "fbmeta-image",
-				Offset: 0,
-				Size:   32 * 1024 * 1024,
-				Type:   FBMETA_IMAGE,
-			},
-		},
-	},
+	MetaPartitionImageFormat,
 	{
 		Name: "vboot",
 		PartitionConfigs: []PartitionConfigInfo{

--- a/tools/flashy/lib/validate/validate.go
+++ b/tools/flashy/lib/validate/validate.go
@@ -27,11 +27,11 @@ import (
 )
 
 // Validate tries to validate partitions according to all configs defined in
-// partition.ImageFormats. If one succeeds, return nil. If none succeeds,
+// imageFormats. If one succeeds, return nil. If none succeeds,
 // validation has failed, return the error.
 // Supports both data from image file and flash device
-var Validate = func(data []byte) error {
-	for _, imageFormat := range partition.ImageFormats {
+var Validate = func(data []byte, imageFormats []partition.ImageFormat) error {
+	for _, imageFormat := range imageFormats {
 		log.Printf("*** Attempting to validate using image format '%v' ***",
 			imageFormat.Name)
 

--- a/tools/flashy/lib/validate/validate_test.go
+++ b/tools/flashy/lib/validate/validate_test.go
@@ -29,11 +29,9 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	// mock and defer restore ImageFormats, ValidatePartitionsFromPartitionConfigs
-	imageFormatsOrig := partition.ImageFormats
+	// mock and defer restore ValidatePartitionsFromPartitionConfigs
 	validatePartitionsFromPartitionConfigsOrig := partition.ValidatePartitionsFromPartitionConfigs
 	defer func() {
-		partition.ImageFormats = imageFormatsOrig
 		partition.ValidatePartitionsFromPartitionConfigs = validatePartitionsFromPartitionConfigsOrig
 	}()
 
@@ -90,7 +88,6 @@ func TestValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			exampleData := []byte("abcd")
 			i := 0
-			partition.ImageFormats = tc.imageFormats
 			partition.ValidatePartitionsFromPartitionConfigs = func(
 				data []byte,
 				partitionConfigs []partition.PartitionConfigInfo,
@@ -104,7 +101,7 @@ func TestValidate(t *testing.T) {
 				return tc.validatePartitionsErrs[idx]
 			}
 
-			got := Validate(exampleData)
+			got := Validate(exampleData, tc.imageFormats)
 			tests.CompareTestErrors(tc.want, got, t)
 		})
 	}

--- a/tools/flashy/utilities/check-image.go
+++ b/tools/flashy/utilities/check-image.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/facebook/openbmc/tools/flashy/lib/step"
 	"github.com/facebook/openbmc/tools/flashy/lib/validate/image"
+	"github.com/facebook/openbmc/tools/flashy/lib/validate/partition"
 )
 
 func init() {
@@ -41,6 +42,8 @@ Usage: check-image FILE DEVICE_ID
 
 DEVICE_ID is optional and denotes the target flash device ID (e.g. mtd:flash0), which is used
 to ensure that the image file size is smaller than that of the target flash device.
+
+Note that validation here checks against all known valid image formats.
 `)
 }
 
@@ -55,5 +58,5 @@ func checkImage(args []string) error {
 	if len(args) == 3 {
 		maybeDeviceID = args[2]
 	}
-	return image.ValidateImageFile(imageFilePath, maybeDeviceID)
+	return image.ValidateImageFile(imageFilePath, maybeDeviceID, partition.ImageFormats)
 }


### PR DESCRIPTION
# Summary
- Add `imageFormats` (a list of valid image partition formats) as arguments to `Validate` and `ValidateImageFile` so that validation can run against specific image formats.
- Add step for `grandcanyon` meta partition validation--corresponding diff in `fw-util`: https://github.com/facebook/openbmc/commit/bc32863c97e396e41a9c2054d2e2806562632310

## Discussion
For `grandcanyon` devices image partition validation essentially will be run _twice_, once via the common step, then once again in the newly added step. This might seem inefficient, but IMO is a necessary overhead if we were to stick to flashy's platform-based abstraction. There are potential workarounds:
  - Get the `buildname` within `flashy` itself, then obtain the right formats to validate against, as seen in #151 
    - breaks `flashy`'s platform-folder abstraction
  - Detect the presence of this step in the common validation step and skip validation there
    - Complex and again, breaks the abstraction
   
Thus, double-validation is done. Given that this extra step should not add much time to the whole flash process it should be a non-issue.

## Test plan
Unit tests `go test ./...`
testhard