### PR TITLE
flashy: Fix nit in tests where test is not run under test case name.

### DIFF
--- a/tools/flashy/lib/fileutils/fileutils_test.go
+++ b/tools/flashy/lib/fileutils/fileutils_test.go
@@ -143,15 +143,17 @@ func TestFileExists(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		buf = bytes.Buffer{}
-		osStat = func(filename string) (os.FileInfo, error) {
-			return &mockFileInfo{tc.isDir, nil}, tc.osStatErr
-		}
-		got := FileExists("x")
-		if tc.want != got {
-			t.Errorf("want %v got %v", tc.want, got)
-		}
-		tests.LogContainsSeqTest(buf.String(), tc.logContainsSeq, t)
+		t.Run(tc.name, func(t *testing.T) {
+			buf = bytes.Buffer{}
+			osStat = func(filename string) (os.FileInfo, error) {
+				return &mockFileInfo{tc.isDir, nil}, tc.osStatErr
+			}
+			got := FileExists("x")
+			if tc.want != got {
+				t.Errorf("want %v got %v", tc.want, got)
+			}
+			tests.LogContainsSeqTest(buf.String(), tc.logContainsSeq, t)
+		})
 	}
 }
 
@@ -205,15 +207,17 @@ func TestDirExists(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		buf = bytes.Buffer{}
-		osStat = func(filename string) (os.FileInfo, error) {
-			return &mockFileInfo{tc.isDir, nil}, tc.osStatErr
-		}
-		got := DirExists("x")
-		if tc.want != got {
-			t.Errorf("want %v got %v", tc.want, got)
-		}
-		tests.LogContainsSeqTest(buf.String(), tc.logContainsSeq, t)
+		t.Run(tc.name, func(t *testing.T) {
+			buf = bytes.Buffer{}
+			osStat = func(filename string) (os.FileInfo, error) {
+				return &mockFileInfo{tc.isDir, nil}, tc.osStatErr
+			}
+			got := DirExists("x")
+			if tc.want != got {
+				t.Errorf("want %v got %v", tc.want, got)
+			}
+			tests.LogContainsSeqTest(buf.String(), tc.logContainsSeq, t)
+		})
 	}
 }
 

--- a/tools/flashy/lib/utils/helper_test.go
+++ b/tools/flashy/lib/utils/helper_test.go
@@ -51,10 +51,12 @@ func TestStringFind(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		got := StringFind(tc.val, tc.arr)
-		if tc.want != got {
-			t.Errorf("want '%v' got '%v'", tc.want, got)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got := StringFind(tc.val, tc.arr)
+			if tc.want != got {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
+		})
 	}
 }
 
@@ -108,10 +110,12 @@ func TestUint32Find(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		got := Uint32Find(tc.val, tc.arr)
-		if tc.want != got {
-			t.Errorf("want '%v' got '%v'", tc.want, got)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got := Uint32Find(tc.val, tc.arr)
+			if tc.want != got {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
+		})
 	}
 }
 
@@ -501,11 +505,13 @@ func TestGetWord(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		got, err := GetWord(tc.data, tc.offset)
-		if tc.want != got {
-			t.Errorf("want '%v' got '%v'", tc.want, got)
-		}
-		tests.CompareTestErrors(tc.wantErr, err, t)
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GetWord(tc.data, tc.offset)
+			if tc.want != got {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
+			tests.CompareTestErrors(tc.wantErr, err, t)
+		})
 	}
 }
 
@@ -545,11 +551,13 @@ func TestSetWord(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		got, err := SetWord(tc.data, tc.word, tc.offset)
-		if !bytes.Equal(tc.want, got) {
-			t.Errorf("want '%v' got '%v'", tc.want, got)
-		}
-		tests.CompareTestErrors(tc.wantErr, err, t)
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SetWord(tc.data, tc.word, tc.offset)
+			if !bytes.Equal(tc.want, got) {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
+			tests.CompareTestErrors(tc.wantErr, err, t)
+		})
 	}
 }
 

--- a/tools/flashy/lib/utils/pfr_test.go
+++ b/tools/flashy/lib/utils/pfr_test.go
@@ -58,11 +58,10 @@ func TestIsPfrSystem(t *testing.T) {
 				}
 				return tc.exitCode, nil, "", ""
 			}
+			got := IsPfrSystem()
+			if tc.want != got {
+				t.Errorf("want '%v' got '%v'", tc.want, got)
+			}
 		})
-
-		got := IsPfrSystem()
-		if tc.want != got {
-			t.Errorf("want '%v' got '%v'", tc.want, got)
-		}
 	}
 }

--- a/tools/flashy/lib/validate/compatibility_test.go
+++ b/tools/flashy/lib/validate/compatibility_test.go
@@ -95,7 +95,6 @@ func TestCheckImageBuildNameCompatibility(t *testing.T) {
 
 	compatibleVersionMapping = map[string]string{"fby2-gpv2": "fbgp2"}
 	for _, tc := range cases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			exampleImageFilePath := "/opt/upgrade/mock"
 			utils.GetOpenBMCVersionFromIssueFile = func() (string, error) {

--- a/tools/flashy/lib/validate/partition/p_fbmeta_md5_test.go
+++ b/tools/flashy/lib/validate/partition/p_fbmeta_md5_test.go
@@ -103,5 +103,4 @@ func TestFBMetaMD5Validate(t *testing.T) {
 			tests.CompareTestErrors(tc.want, got, t)
 		})
 	}
-
 }

--- a/tools/flashy/lib/validate/partition/p_fbmeta_test.go
+++ b/tools/flashy/lib/validate/partition/p_fbmeta_test.go
@@ -179,7 +179,6 @@ func TestFBMetaValidate(t *testing.T) {
 			tests.CompareTestErrors(tc.want, got, t)
 		})
 	}
-
 }
 
 // parse an example


### PR DESCRIPTION
# Summary 
As title. Been meaning to do this for quite some time.

## Context
I'm addicted to parameterised tests--there's no denying that. One problem in Golang is that you can get away with forgetting to use `t.Run(<test-name>...` when doing parameterised tests. This is fine, but the effect is that when tests fail, you don't see which exact test case failed. This makes it hard to debug.

This diff fixes that. 

## Test plan
- Unit tests remain passing.
- Make sure number of occurrences of parameterised tests correspond with `t.Run(<test-name>...):
```
tools/flashy$ shopt -s globstar
tools/flashy$ grep -o -i "range cases" **/*_test.go | wc -l
99
tools/flashy$ grep -o -i "t.Run(tc.name" **/*_test.go | wc -l
99
```