### PR TITLE
flashy: Close all opened files and Munmap mmap-ed buffers

### DIFF
--- a/tools/flashy/lib/fileutils/fileutils.go
+++ b/tools/flashy/lib/fileutils/fileutils.go
@@ -157,11 +157,8 @@ var AppendFile = func(filename, data string) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	_, err = f.Write([]byte(data))
-	if err != nil {
-		return err
-	}
-	err = f.Close()
 	if err != nil {
 		return err
 	}

--- a/tools/flashy/lib/fileutils/fileutils.go
+++ b/tools/flashy/lib/fileutils/fileutils.go
@@ -258,6 +258,7 @@ var GetPageOffsettedOffset = func(addr uint32) uint32 {
 }
 
 // OpenFileWithLock opens an existing file and acquires a lock for it.
+// Remember to call CloseFileWithUnlock to release the lock.
 var OpenFileWithLock = func(filename string, flag int, how int) (*os.File, error) {
 	f, err := os.OpenFile(filename, flag, 0)
 	if err != nil {

--- a/tools/flashy/lib/fileutils/fileutils.go
+++ b/tools/flashy/lib/fileutils/fileutils.go
@@ -56,6 +56,9 @@ var ReadFile = ioutil.ReadFile
 var WriteFile = ioutil.WriteFile // prefer WriteFileWithTimeout
 var RenameFile = os.Rename
 var CreateFile = os.Create
+
+// Mmap is syscall.Mmap.
+// Remember to call Munmap to unmap.
 var Mmap = syscall.Mmap
 var Munmap = syscall.Munmap
 var Glob = filepath.Glob
@@ -183,6 +186,7 @@ var IsELFFile = func(filename string) bool {
 }
 
 // MmapFile is a convenience function to mmap an entire file.
+// Remember to call Munmap to unmap.
 var MmapFile = func(filename string, prot, flags int) ([]byte, error) {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -202,6 +206,7 @@ var MmapFile = func(filename string, prot, flags int) ([]byte, error) {
 }
 
 // MmapFileRange is a convenience function to mmap a given range of a file.
+// Remember to call Munmap to unmap.
 var MmapFileRange = func(filename string, offset int64, length, prot, flags int) ([]byte, error) {
 	if offset%int64(os.Getpagesize()) != 0 {
 		return nil, errors.Errorf(

--- a/tools/flashy/lib/fileutils/fileutils.go
+++ b/tools/flashy/lib/fileutils/fileutils.go
@@ -178,6 +178,7 @@ var IsELFFile = func(filename string) bool {
 			"assuming that it is not an ELF file", filename, err)
 		return false
 	}
+	defer Munmap(buf)
 	return bytes.Equal(buf, elfMagicNumber)
 }
 

--- a/tools/flashy/lib/fileutils/fileutils_test.go
+++ b/tools/flashy/lib/fileutils/fileutils_test.go
@@ -218,10 +218,11 @@ func TestDirExists(t *testing.T) {
 }
 
 func TestIsELFFile(t *testing.T) {
-	// mock and defer restore MmapFileRange
 	mmapFileRangeOrig := MmapFileRange
+	munmapOrig := Munmap
 	defer func() {
 		MmapFileRange = mmapFileRangeOrig
+		Munmap = munmapOrig
 	}()
 
 	cases := []struct {
@@ -254,6 +255,9 @@ func TestIsELFFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			MmapFileRange = func(filename string, offset int64, length, prot, flags int) ([]byte, error) {
 				return tc.mmapRet, tc.mmapErr
+			}
+			Munmap = func(b []byte) (err error) {
+				return nil
 			}
 			got := IsELFFile("x")
 			if tc.want != got {

--- a/tools/flashy/lib/flash/flashcp/flashcp.go
+++ b/tools/flashy/lib/flash/flashcp/flashcp.go
@@ -147,6 +147,7 @@ var FlashCp = func(imageFilePath, deviceFilePath string, roOffset uint32) error 
 
 // openFlashDeviceFile is a wrapper around OpenFileWithLock intended to return
 // an os.File which implements flashDeviceFile.
+// remember to call closeFlashDeviceFile to close the flash device file.
 var openFlashDeviceFile = func(deviceFilePath string) (flashDeviceFile, error) {
 	return fileutils.OpenFileWithLock(deviceFilePath, os.O_SYNC|os.O_RDWR, syscall.LOCK_EX)
 }

--- a/tools/flashy/lib/flash/flashutils/devices/mtd.go
+++ b/tools/flashy/lib/flash/flashutils/devices/mtd.go
@@ -80,7 +80,7 @@ func (m *MemoryTechnologyDevice) GetFileSize() uint64 {
 }
 
 // MmapRO mmaps the whole file in readonly mode.
-// A Munmap call is required to release the buffer.
+// Remember to call Munmap to unmap.
 func (m *MemoryTechnologyDevice) MmapRO() ([]byte, error) {
 	// use mmap
 	mmapFilePath, err := GetMTDBlockFilePath(m.FilePath)

--- a/tools/flashy/lib/utils/system.go
+++ b/tools/flashy/lib/utils/system.go
@@ -454,6 +454,7 @@ func tryPetWatchdog() bool {
 	if err != nil {
 		return false
 	}
+	defer f.Close()
 
 	// Extend the timeout.  The kernel may adjust the timeout downward
 	// if a hardware watchdog is in use.  In any case, don't arrange to
@@ -469,7 +470,6 @@ func tryPetWatchdog() bool {
 	if err3 != nil {
 		log.Printf("ioctl WDIOC_KEEPALIVE failed: %v", err3)
 	}
-	f.Close()
 	return err2 == nil && err3 == nil
 }
 

--- a/tools/flashy/lib/utils/system.go
+++ b/tools/flashy/lib/utils/system.go
@@ -452,6 +452,7 @@ func tryPetWatchdog() bool {
 
 	f, err := os.OpenFile("/dev/watchdog", os.O_RDWR, 0)
 	if err != nil {
+		log.Printf("Not petting watchdog: unable to open /dev/watchdog: %v", err)
 		return false
 	}
 	defer f.Close()

--- a/tools/flashy/lib/utils/vboot.go
+++ b/tools/flashy/lib/utils/vboot.go
@@ -145,6 +145,7 @@ var GetVbs = func() (Vbs, error) {
 	if err != nil {
 		return vbs, errors.Errorf("Unable to mmap /dev/mem: %v", err)
 	}
+	defer fileutils.Munmap(pageData)
 
 	dataOffset := fileutils.GetPageOffsettedOffset(AST_SRAM_VBS_BASE)
 	vbsEndOffset, err := AddU32(dataOffset, AST_SRAM_VBS_SIZE)

--- a/tools/flashy/lib/utils/vboot_test.go
+++ b/tools/flashy/lib/utils/vboot_test.go
@@ -106,14 +106,15 @@ func TestVbootPartitionExists(t *testing.T) {
 
 // also tests encode and decode
 func TestGetVbs(t *testing.T) {
-	// mock and defer restore MmapFileRange, GetPageOffsettedOffset & vbootPartitionExists
 	mmapFileRangeOrig := fileutils.MmapFileRange
 	getPageOffsettedOffsetOrig := fileutils.GetPageOffsettedOffset
 	vbootPartitionExistsOrig := vbootPartitionExists
+	munmapOrig := fileutils.Munmap
 	defer func() {
 		fileutils.MmapFileRange = mmapFileRangeOrig
 		fileutils.GetPageOffsettedOffset = getPageOffsettedOffsetOrig
 		vbootPartitionExists = vbootPartitionExistsOrig
+		fileutils.Munmap = munmapOrig
 	}()
 	vbootPartitionExists = func() bool {
 		return true
@@ -149,6 +150,9 @@ func TestGetVbs(t *testing.T) {
 	}
 	fileutils.GetPageOffsettedOffset = func(addr uint32) uint32 {
 		return 0
+	}
+	fileutils.Munmap = func(b []byte) (err error) {
+		return nil
 	}
 
 	got, err := GetVbs()


### PR DESCRIPTION
# Summary
As title. Missed these out. Change the pattern to the idiomatic `defer Munmap/Close` after checking for non-nil Open/Mmap errors.

Add also reminders to munmap/close files in the corresponding mmap/open helper functions

## Test Plan
Unit tests: `go test ./...`

testhard