### PR TITLE
circle-ci: qemu: Add firmware to secondary flash

### DIFF
--- a/tools/circle-ci/cit_test_wrapper.py
+++ b/tools/circle-ci/cit_test_wrapper.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import sys
 import time
+from shutil import copy
 from typing import Tuple
 
 import paramiko
@@ -17,6 +18,7 @@ FLASH_SIZE = 128 * 1024 * 1024
 HOST = "localhost"
 HOST_SSH_FORWARD_PORT = 2222
 QEMU_PARAMETER = "  -machine {} -nographic  -drive file={},format=raw,if=mtd \
+    -drive file={},format=raw,if=mtd \
     -net nic -net user,hostfwd=:127.0.0.1:{}-:22,hostname=qemu"
 PLATFORM_2_MACHINE = {
     "fby2": "yosemitev2-bmc",
@@ -60,7 +62,8 @@ class TestWrapper(object):
         cmd = "/tmp/job/project/qemu-system-arm"
         cmd += QEMU_PARAMETER.format(
             PLATFORM_2_MACHINE[platform],
-            self._padded_image_file,
+            self._golden_image_file,
+            self._primary_image_file,
             HOST_SSH_FORWARD_PORT,
         )
 
@@ -166,6 +169,11 @@ class TestWrapper(object):
         except Exception as e:
             print(f"fail to pad the flash file: {str(e)}")
             sys.exit(1)
+
+        self._golden_image_file = "/tmp/golden.mtd"
+        self._primary_image_file = "/tmp/primary.mtd"
+        copy(self._padded_image_file, self._golden_image_file)
+        copy(self._padded_image_file, self._primary_image_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Up until now, we've only been providing the golden firmware image in the primary flash to QEMU. This means we were always booting in recovery mode, because the secondary flash was undefined, and wouldn't pass verified boot.

Since openbmc.qemu:7, we now support specifying the secondary flash firmware image as an additional -drive MTD argument. We still specify the same firmware file, but this allows verified boot to pass for unsigned images in QEMU, allowing us to run in non-recovery mode in QEMU. We still can't boot signed images in non-recovery mode because the TPM is not emulated at all, so all requests sent to the TPM are ignored and fail. But unsigned images don't require that the TPM verifies the image.