### PR TITLE
circle-ci: cit: Specify PATH in oob ssh commands 

### DIFF
--- a/tools/circle-ci/cit_test_wrapper.py
+++ b/tools/circle-ci/cit_test_wrapper.py
@@ -12,6 +12,7 @@ import pexpect
 from paramiko.channel import ChannelFile, ChannelStderrFile
 from pexpect import EOF, TIMEOUT
 
+PATH = "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 DEFAULT_BMC_USER = "root"
 DEFAULT_OPENBMC_PASSWORD = "0penBmc"
 FLASH_SIZE = 128 * 1024 * 1024
@@ -125,7 +126,7 @@ class TestWrapper(object):
             if count == 0:
                 print("exhaust retry, giving up..")
                 raise paramiko.ssh_exception.SSHException
-        stdin, stdout, stderr = self.ssh.exec_command(cmd)
+        stdin, stdout, stderr = self.ssh.exec_command(f"PATH={PATH} {cmd}")
         exit_status = stdout.channel.recv_exit_status()
         return exit_status, stdout, stderr
 


### PR DESCRIPTION
Summary:
The PATH environment variable is not getting set correctly by the `paramiko` library, and this is the only thing that seems to work.

Test Plan:
Before, the first test would always fail because it couldn't find `cfg-util`:

    python3 tools/circle-ci/cit_test_wrapper.py fby3 -t tests.fby3.test_cfg_util.CfgUtilTest.test_cfg_util_set
    ...
    Running tests.fby3.test_cfg_util.CfgUtilTest.test_cfg_util_set
    tests.fby3.test_cfg_util.CfgUtilTest.test_cfg_util_set: fail
    test_cfg_util_set (tests.fby3.test_cfg_util.CfgUtilTest)
    To test cfg-uti to set slot1_por_cfg value to on then back to original value ... ERROR

    ======================================================================
    ERROR: test_cfg_util_set (tests.fby3.test_cfg_util.CfgUtilTest)
    To test cfg-uti to set slot1_por_cfg value to on then back to original value
    ----------------------------------------------------------------------
    Traceback (most recent call last):
    File "/usr/local/bin/tests2/common/base_cfg_util_test.py", line 55, in test_cfg_util_set
    old_value = run_cmd(cmd_to_show).strip()
    File "/usr/local/bin/tests2/utils/shell_util.py", line 39, in wrap
    return func(*args, **kwargs)
    File "/usr/local/bin/tests2/utils/shell_util.py", line 48, in run_cmd
    info = subprocess.check_output(cmd).decode("utf-8")
    File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
    File "/usr/lib/python3.8/subprocess.py", line 493, in run
    with Popen(*popenargs, **kwargs) as process:
    File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
    File "/usr/lib/python3.8/subprocess.py", line 1704, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
    FileNotFoundError: [Errno 2] No such file or directory: 'cfg-util'

    ----------------------------------------------------------------------
    Ran 1 test in 0.241s

    FAILED (errors=1)
    CIT test complete, PASS: 0, FAIL: 1, TOTAL: 1

But now, with these changes, the test passes:

    python3 tools/circle-ci/cit_test_wrapper.py fby3 -t tests.fby3.test_cfg_util.CfgUtilTest.test_cfg_util_set
    ...
    Running tests.fby3.test_cfg_util.CfgUtilTest.test_cfg_util_set
    tests.fby3.test_cfg_util.CfgUtilTest.test_cfg_util_set: pass
    CIT test complete, PASS: 1, FAIL: 0, TOTAL: 1

Which is what I would expect, because if I just scp the tests2
directory to /usr/local/bin and run the tests manually myself, it
passed:

    python3 cit_runner.py --run-test tests.fby3.test_cfg_util.CfgUtilTest.test_cfg_util_set
    test_cfg_util_set (tests.fby3.test_cfg_util.CfgUtilTest)
    To test cfg-uti to set slot1_por_cfg value to on then back to original value ... ok

    ----------------------------------------------------------------------
    Ran 1 test in 2.264s

    OK