### PR TITLE
circle-ci: Extend CIT timeout to 15m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ jobs:
                     chmod +x qemu-system-arm
             - run:
                 name: execute CIT tests
+                no_output_timeout: 15m
                 command: |
                     python3 tools/circle-ci/cit_test_wrapper.py << parameters.machine >>
     build:


### PR DESCRIPTION
Summary:
fby3 CircleCI tests timeout from no output after 10 minutes. This is because the fw-util test takes approximately 12 minutes. By increasing the timeout a little bit, we should avoid this timeout failure.

Test Plan:
Looking at CircleCI jobs on pull request.