### PR TITLE
circleci: Replace Amazon S3 QEMU file with Github Releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
         docker:
             - image: ubuntu:focal
               environment:
-                  QEMU_URI: https://fb-openbmc-qemu.s3.us-east-2.amazonaws.com
+                  QEMU_URI: https://github.com/facebook/openbmc-qemu/releases/latest/download
               user: root
         resource_class: 2xlarge
         working_directory: /tmp/job/project


### PR DESCRIPTION
Summary:
I added an auto-image-release Github Action to openbmc-qemu, so we can use the URI that specifies the latest Github Release binary instead.

That way we don't have to manually upload the QEMU binary to 2 different places.

Test Plan:
Make sure this doesn't break the CircleCI CIT tests.