### PR TITLE
circleci: Increase QEMU SSH banner timeout

### DIFF
--- a/tools/circle-ci/cit_test_wrapper.py
+++ b/tools/circle-ci/cit_test_wrapper.py
@@ -98,16 +98,17 @@ class TestWrapper(object):
                 continue
 
     def init_ssh(self) -> None:
+        self.ssh = paramiko.SSHClient()
+        self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         count = 10
         while count != 0:
             try:
-                self.ssh = paramiko.SSHClient()
-                self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
                 self.ssh.connect(
                     HOST,
                     HOST_SSH_FORWARD_PORT,
                     DEFAULT_BMC_USER,
                     DEFAULT_OPENBMC_PASSWORD,
+                    banner_timeout=200,
                 )
                 break
             except paramiko.ssh_exception.SSHException:


### PR DESCRIPTION
Summary:
We keep getting these errors where the SSH banner fails to appear:

```
qemu started, checking SSH connection..
Exception (client): Error reading SSH protocol banner
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/paramiko/transport.py", line 2270, in _check_banner
    buf = self.packetizer.readline(timeout)
  File "/usr/local/lib/python3.8/dist-packages/paramiko/packet.py", line 380, in readline
    buf += self._read_timeout(timeout)
  File "/usr/local/lib/python3.8/dist-packages/paramiko/packet.py", line 622, in _read_timeout
    raise socket.timeout()
socket.timeout

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/paramiko/transport.py", line 2093, in run
    self._check_banner()
  File "/usr/local/lib/python3.8/dist-packages/paramiko/transport.py", line 2274, in _check_banner
    raise SSHException(
paramiko.ssh_exception.SSHException: Error reading SSH protocol banner
```

According to [StackOverflow](https://stackoverflow.com/questions/25609153/paramiko-error-reading-ssh-protocol-banner), this is likely because `sshd` is not responding with the banner message quickly enough. It's hard to tell, because it's not particularly reproducible. I'm attempting to resolve it by increasing the banner timeout. The existing mechanism does not help in this case.

Test Plan:
Looking at CircleCI results.