### PR TITLE
circleci: Fix rest-api unit-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,42 +54,16 @@ jobs:
             - image: crops/poky:latest
               environment:
                   MACHINE: qemux86
-                  CACHE_DIR: /tmp/job/sstate-cache
-                  CACHE_URI: https://fb-openbmc-sstate.s3.us-east-2.amazonaws.com
               user: root
         resource_class: 2xlarge
-        working_directory: /tmp/job/project
+        working_directory: /mnt/ramdisk
         steps:
             - attach_workspace:
                 at: /tmp/job
             - run:
-                name: Set up git config for testing user.
-                command: |
-                    git config --global user.email "openbmc-circleci@fb.com"
-                    git config --global user.name "CircleCI Testing"
-            - run:
-                name: Adding usersetup to sudoer
-                command: |
-                    sed -e '/usersetup/ s/^#*/#/' -i /etc/sudoers.usersetup
-                    echo "usersetup ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.usersetup
-            - run:
-                name: Update working folder ownership
-                command: |
-                    chown -R usersetup:usersetup /tmp/job
-            - run:
-                name: Check build required. Halt the CI if not needed.
-                command: |
-                    if ! runuser -m usersetup -c './tools/circle-ci/check-build-required ptest'; then
-                        circleci-agent step halt
-                    fi
-            - run:
-                name: Download sstate cache.
-                command: |
-                    runuser -m usersetup -c './tools/circle-ci/download-sstate-cache'
-            - run:
                 name: Build qemux86 and run package-test within
                 command: |
-                    runuser -m usersetup -c 'python3 tests2/ptest-runner -b build --force-rebuild --verbose'
+                    python3 /tmp/job/project/tests2/ptest-runner -b /tmp/job/project/build --verbose
     qemu-cit:
         parameters:
             machine:
@@ -180,15 +154,13 @@ jobs:
                 root: /tmp/job
                 paths:
                   - project/build/tmp/deploy/images/<< parameters.machine >>/flash-<< parameters.machine >>*
+                  - project/build/tmp/deploy/images/<< parameters.machine >>/*.tar.bz2
 workflows:
     version: 2
     everything:
         jobs:
             - lint
             - setup
-            - unit-test:
-                requires:
-                    - setup
             - build:
                 name: build-<< matrix.machine >>
                 requires:
@@ -219,7 +191,11 @@ workflows:
                             wedge400,
                             yamp,
                             yosemite,
+                            qemux86,
                             ]
+            - unit-test:
+                requires:
+                    - build-qemux86
             - qemu-cit:
                 name: qemu-cit-<< matrix.machine >>
                 requires:

--- a/common/recipes-rest/rest-api/rest-api_0.1.bb
+++ b/common/recipes-rest/rest-api/rest-api_0.1.bb
@@ -244,7 +244,6 @@ cat <<EOF > ${WORKDIR}/run-ptest
   coverage erase
   coverage run -m unittest discover /usr/local/fbpackages/rest-api
   coverage report -m --omit="*/test*"
-  mount -t tmpfs -o size=512m tmpfs /dev/shm
   echo "[Flake8]"
   flake8  --config /usr/local/fbpackages/rest-api/.flake8 /usr/local/fbpackages/rest-api/*.py
   echo "[MYPY]"

--- a/tests2/ptest-runner
+++ b/tests2/ptest-runner
@@ -153,7 +153,7 @@ def main(args):
     deploy = args.build + "/tmp/deploy/images/qemux86"
     rootfs_zip = deploy + "/qemux86-image-qemux86.tar.bz2"
     rootfs_zip = os.path.abspath(rootfs_zip)
-    rootfs = deploy + "/rootfs"
+    rootfs = "./rootfs"
     if os.path.isdir(rootfs):
         shutil.rmtree(rootfs)
     os.makedirs(rootfs)
@@ -164,17 +164,26 @@ def main(args):
     )  # fake shm,tmp for flake8
     if not os.path.exists("/.dockerenv"):
         base_cmd = ["unshare", "--mount", "--map-root-user", "chroot", rootfs]
+        init_steps = ["mount -t tmpfs -o size=512m tmpfs /dev/shm"]
     else:
+        # It's not necessary to mount /dev/shm as tmpfs in CircleCI because we
+        # unpack the rootfs within /mnt/ramdisk, which is already a tmpfs.
         base_cmd = ["sudo", "chroot", rootfs]
+        init_steps = []
+
     if args.shell:
-        subprocess.check_call(base_cmd + ["bash"])
+        init_file = "/init-file.sh"
+        with open(rootfs + init_file, "w") as f:
+            f.write("\n".join(init_steps))
+        subprocess.check_call(base_cmd + ["bash", "--init-file", init_file])
     elif not args.skip_tests:
-        cmd = base_cmd + ["ptest-runner"]
         exit_error = False
         if args.recipes is None or len(args.recipes) == 0:
-            cmd += all_recipes
+            recipes = all_recipes
         else:
-            cmd += args.recipes
+            recipes = args.recipes
+        ptest_cmd = " ".join(["ptest-runner"] + recipes)
+        cmd = base_cmd + ["bash", "-c", " && ".join(init_steps + [ptest_cmd])]
         try:
             out = subprocess.check_output(cmd).decode()
             print(out)

--- a/tools/circle-ci/do-build
+++ b/tools/circle-ci/do-build
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -ex
 
-source "$(dirname "${BASH_SOURCE[0]}")/../../openbmc-init-build-env" \
-    "$MACHINE" build
+MACHINE="${MACHINE:?}"
+
+source openbmc-init-build-env "$MACHINE" build
+if [ "$MACHINE" == "qemux86" ]; then
+  python3 ../tests2/ptest-runner -b . -u
+fi
 bitbake "$MACHINE-image"


### PR DESCRIPTION
circleci: Fix rest-api unit-test

Summary:
`rest-api` unit tests are failing on the Flake8 step in CircleCI (but not in Sandcastle), this refactors the CircleCI setup to allow Flake8 to pass.

Full context on this fix:

- `rest-api` unit tests use Flake8 to type check Python 3 type annotations.
- Flake8 uses Python 3 `multiprocessing`.
- `multiprocessing` uses POSIX semaphores.
- POSIX semaphores use `/dev/shm` on Linux ([man7](https://man7.org/linux/man-pages/man7/sem_overview.7.html))
- `/dev/shm` is a `tmpfs` virtual filesystem.
- So, Flake8 needs `/dev/shm`.
- Unit tests run inside the `qemux86-image` rootfs using `chroot`.
- The `qemux86-image` rootfs doesn't have `/dev/shm`.
- In Sandcastle, we manually create `.../qemux86-image-rootfs/dev/shm` and mount a 512MB `tmpfs` there.
- In CircleCI, we _cannot_ create new `tmpfs` mounts ([Forum thread](https://discuss.circleci.com/t/will-privileged-containers-sys-admin-and-dev-fuse-be-supported/35869)).
- So, `flake8` fails in CircleCI with "permission denied" while trying to mount `/dev/shm`.

The fix in this diff (#thanks @patrickw3 for suggesting [this](https://circleci.com/docs/2.0/executor-types/#ram-disks)) is to unpack the `qemux86-image` rootfs _within_ an existing `tmpfs`, in this case, `/mnt/ramdisk`. That way, `/dev/shm` is automatically a `tmpfs`.

I've also decoupled the `build-qemux86` and `unit-test` jobs in this diff as well, so that we can run `ptest-runner` as `root`, but still build the `qemux86-image` as a non-root user (which `bitbake` requires). This is so that we can move the `mount` command from the rest-api recipe to `ptest-runner`.

Lastly, to move the `/dev/shm` mounting step from the rest-api recipe to `ptest-runner`, I needed to refactor the shell command we use when entering the chroot to run a series of commands everytime we enter the chroot. Everytime we exit the chroot, the mount will disappear.

Test Plan:
Making sure CircleCI and Sandcastle unit-tests pass.