### PR TITLE
tests2: Remove qemu_check filters

### DIFF
--- a/tests2/common/base_rest_endpoint_test.py
+++ b/tests2/common/base_rest_endpoint_test.py
@@ -25,7 +25,6 @@ import unittest
 from abc import abstractmethod
 
 from utils.cit_logger import Logger
-from utils.test_utils import qemu_check
 
 
 try:
@@ -264,7 +263,6 @@ class CommonRestEndpointTest(BaseRestEndpointTest):
         self.endpoint_sys_attrb = None
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys(self):
         self.set_endpoint_sys_attributes()
         self.verify_endpoint_attributes(
@@ -277,7 +275,6 @@ class CommonRestEndpointTest(BaseRestEndpointTest):
         self.endpoint_sensors_attrb = None
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_sensors(self):
         self.set_endpoint_sensors_attributes()
         self.verify_endpoint_attributes(
@@ -288,7 +285,6 @@ class CommonRestEndpointTest(BaseRestEndpointTest):
     def set_endpoint_mb_attributes(self):
         self.endpoint_mb_attrb = self.MB_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_mb(self):
         self.set_endpoint_mb_attributes()
         self.verify_endpoint_attributes(
@@ -301,7 +297,6 @@ class CommonRestEndpointTest(BaseRestEndpointTest):
         self.endpoint_server_attrb = None
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_server(self):
         self.set_endpoint_server_attributes()
         self.verify_endpoint_attributes(
@@ -312,7 +307,6 @@ class CommonRestEndpointTest(BaseRestEndpointTest):
     def set_endpoint_fruid_attributes(self):
         self.endpoint_fruid_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_mb_fruid(self):
         self.set_endpoint_fruid_attributes()
         self.verify_endpoint_attributes(
@@ -323,7 +317,6 @@ class CommonRestEndpointTest(BaseRestEndpointTest):
     def set_endpoint_bmc_attributes(self):
         self.endpoint_bmc_attrb = self.BMC_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_bmc(self):
         self.set_endpoint_bmc_attributes()
         self.verify_endpoint_attributes(
@@ -334,7 +327,6 @@ class CommonRestEndpointTest(BaseRestEndpointTest):
     def set_endpoint_mtd_attributes(self):
         self.endpoint_mtd_attrb = ["u-boot", "env", "fit", "data0", "flash0", "flash1"]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_bmc_mtd(self):
         self.set_endpoint_mtd_attributes()
         info = self.get_from_endpoint(CommonRestEndpointTest.BMC_ENDPOINT)
@@ -344,7 +336,6 @@ class CommonRestEndpointTest(BaseRestEndpointTest):
                 self.assertIn(attrib, dict_info["Information"]["MTD Parts"])
 
     # /api/sys/bmc - Secondary Boot Triggered
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_bmc_secondary_boot(self):
         info = self.get_from_endpoint(CommonRestEndpointTest.BMC_ENDPOINT)
         dict_info = json.loads(info)
@@ -366,14 +357,12 @@ class FbossRestEndpointTest(CommonRestEndpointTest):
     def set_endpoint_fc_present_attributes(self):
         self.endpoint_fc_present_attrb = ["Not Applicable"]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fc_present(self):
         self.set_endpoint_fc_present_attributes()
         self.verify_endpoint_attributes(
             FbossRestEndpointTest.FC_PRESENT_ENDPOINT, self.endpoint_fc_present_attrb
         )
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_firmware_info_all(self):
         self.set_endpoint_firmware_info_all_attributes()
         self.assertNotEqual(self.endpoint_firmware_info_all_attrb, None)

--- a/tests2/tests/cloudripper/test_bic.py
+++ b/tests2/tests/cloudripper/test_bic.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_bic_test import CommonBicTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class BicTest(CommonBicTest, unittest.TestCase):
     def set_bic_cmd(self):
         self.bic_cmd = "/usr/bin/bic-util scm"

--- a/tests2/tests/cloudripper/test_eeprom.py
+++ b/tests2/tests/cloudripper/test_eeprom.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_eeprom_test import CommonEepromTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class EepromTest(CommonEepromTest, unittest.TestCase):
     """
     Test for weutil

--- a/tests2/tests/cloudripper/test_emmc.py
+++ b/tests2/tests/cloudripper/test_emmc.py
@@ -20,13 +20,11 @@
 import unittest
 
 from common.base_emmc_test import BaseEmmcTest
-from utils.test_utils import qemu_check
 
 
 class FujiEmmcTest(BaseEmmcTest, unittest.TestCase):
     def set_emmc_mount_point(self):
         self.emmc_mountpoint = "/mnt/data1"
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_emmc(self):
         super().test_emmc()

--- a/tests2/tests/cloudripper/test_fans.py
+++ b/tests2/tests/cloudripper/test_fans.py
@@ -22,10 +22,8 @@ import unittest
 
 from common.base_fans_test import CommonShellBasedFansTest
 from utils.cit_logger import Logger
-from utils.test_utils import running_systemd, qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FansTest(CommonShellBasedFansTest, unittest.TestCase):
     def setUp(self):
         Logger.start(name=self._testMethodName)

--- a/tests2/tests/cloudripper/test_fscd.py
+++ b/tests2/tests/cloudripper/test_fscd.py
@@ -23,10 +23,8 @@ import unittest
 from common.base_fscd_test import BaseFscdTest
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FscdTest(BaseFscdTest, unittest.TestCase):
 
     TEST_DATA_PATH = "/usr/local/bin/tests2/tests/cloudripper/test_data/fscd"

--- a/tests2/tests/cloudripper/test_gibraltar.py
+++ b/tests2/tests/cloudripper/test_gibraltar.py
@@ -20,7 +20,6 @@
 import unittest
 
 from common.base_switch_test import BaseSwitchTest
-from utils.test_utils import qemu_check
 
 
 class GibraltarTest(BaseSwitchTest, unittest.TestCase):
@@ -31,6 +30,5 @@ class GibraltarTest(BaseSwitchTest, unittest.TestCase):
     def set_swtich_node_cmd(self):
         self.path = "/sys/bus/i2c/drivers/smb_syscpld/12-003e/gb_turn_on"
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_syscpld_nodes_GB_turn_on(self):
         super().test_syscpld_nodes_GB_turn_on()

--- a/tests2/tests/cloudripper/test_host_mac.py
+++ b/tests2/tests/cloudripper/test_host_mac.py
@@ -20,17 +20,14 @@
 import unittest
 
 from common.base_host_mac_test import BaseHostMacTest
-from utils.test_utils import qemu_check
 
 
 class HostMacTest(BaseHostMacTest, unittest.TestCase):
     def set_host_mac(self):
         self.host_mac_cmd = ["/usr/local/bin/wedge_us_mac.sh"]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_host_mac(self):
         super().test_host_mac()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_host_mac_zero_test(self):
         super().test_host_mac_zero_test()

--- a/tests2/tests/cloudripper/test_i2c.py
+++ b/tests2/tests/cloudripper/test_i2c.py
@@ -21,13 +21,11 @@ import unittest
 
 from common.base_i2c_test import BaseI2cTest
 from tests.cloudripper.test_data.i2c.i2c import plat_i2c_tree
-from utils.test_utils import qemu_check
 
 
 class I2cTest(BaseI2cTest, unittest.TestCase):
     def load_golden_i2c_tree(self):
         self.i2c_tree = plat_i2c_tree
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_i2c_tree(self):
         super().test_i2c_tree()

--- a/tests2/tests/cloudripper/test_i2c_driver_presence.py
+++ b/tests2/tests/cloudripper/test_i2c_driver_presence.py
@@ -20,7 +20,6 @@
 import unittest
 
 from common.base_i2c_driver_presence_test import BaseI2cDriverPresenceTest
-from utils.test_utils import qemu_check
 
 
 class CloudripperI2cDriverPresenceTest(BaseI2cDriverPresenceTest, unittest.TestCase):
@@ -44,6 +43,5 @@ class CloudripperI2cDriverPresenceTest(BaseI2cDriverPresenceTest, unittest.TestC
             "fcbcpld",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_i2c_driver_presence(self):
         super().test_i2c_driver_presence()

--- a/tests2/tests/cloudripper/test_kv.py
+++ b/tests2/tests/cloudripper/test_kv.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_kv_test import BaseKvTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class KvTest(BaseKvTest, unittest.TestCase):
     def set_kv_keys(self):
         self.kv_keys = [

--- a/tests2/tests/cloudripper/test_libpal.py
+++ b/tests2/tests/cloudripper/test_libpal.py
@@ -20,10 +20,8 @@
 import unittest
 
 import common.base_libpal_test
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class LibPalTest(common.base_libpal_test.LibPalTest):
     PLATFORM_NAME = "cloudripper"
 

--- a/tests2/tests/cloudripper/test_obmc_mmc.py
+++ b/tests2/tests/cloudripper/test_obmc_mmc.py
@@ -20,9 +20,7 @@
 import unittest
 
 import common.base_obmc_mmc_test
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class LibObmcMmcTest(common.base_obmc_mmc_test.LibObmcMmcTest):
     pass  # just run common tests

--- a/tests2/tests/cloudripper/test_psu.py
+++ b/tests2/tests/cloudripper/test_psu.py
@@ -21,17 +21,14 @@
 import unittest
 
 from common.base_psu_test import CommonPsuTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Psu1Test(CommonPsuTest, unittest.TestCase):
     def set_psu_cmd(self):
         self.psu_cmd = "/usr/bin/psu-util"
         self.psu_id = 1
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Psu2Test(CommonPsuTest, unittest.TestCase):
     def set_psu_cmd(self):
         self.psu_cmd = "/usr/bin/psu-util"

--- a/tests2/tests/cloudripper/test_rest_endpoint.py
+++ b/tests2/tests/cloudripper/test_rest_endpoint.py
@@ -30,7 +30,6 @@ from tests.cloudripper.test_data.sensors.sensor import (
 )
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
 class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
@@ -81,7 +80,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             "fscd_sensor_data",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys(self):
         self.set_endpoint_sys_attributes()
         self.verify_endpoint_attributes(
@@ -105,7 +103,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
         if self.check_fru_sensors_present("psu2"):
             self.endpoint_sensors_attrb += PSU2_SENSORS
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_sensors(self):
         self.set_endpoint_sensors_attributes()
         self.verify_endpoint_attributes(
@@ -128,7 +125,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_scm_attributes(self):
         self.endpoint_fruid_scm_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_scm(self):
         self.set_endpoint_fruid_scm_attributes()
         self.verify_endpoint_attributes(
@@ -139,7 +135,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_mb_fruid_attributes(self):
         self.endpoint_mb_fruid_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_seutil_fruid(self):
         self.set_endpoint_mb_fruid_attributes()
         self.verify_endpoint_attributes(
@@ -150,7 +145,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fcm_attributes(self):
         self.endpoint_fruid_fcm_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fcm(self):
         self.set_endpoint_fruid_fcm_attributes()
         self.verify_endpoint_attributes(
@@ -161,7 +155,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan1_attributes(self):
         self.endpoint_fruid_fan1_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan1(self):
         self.set_endpoint_fruid_fan1_attributes()
         self.verify_endpoint_attributes(
@@ -172,7 +165,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan2_attributes(self):
         self.endpoint_fruid_fan2_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan2(self):
         self.set_endpoint_fruid_fan2_attributes()
         self.verify_endpoint_attributes(
@@ -183,7 +175,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan3_attributes(self):
         self.endpoint_fruid_fan3_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan3(self):
         self.set_endpoint_fruid_fan3_attributes()
         self.verify_endpoint_attributes(
@@ -194,7 +185,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan4_attributes(self):
         self.endpoint_fruid_fan4_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan4(self):
         self.set_endpoint_fruid_fan4_attributes()
         self.verify_endpoint_attributes(
@@ -301,7 +291,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             "P1V05 VR Version",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_firmware_info_all(self):
         self.set_endpoint_firmware_info_all_attributes()
         self.verify_endpoint_attributes(
@@ -335,7 +324,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
         return True
 
     # "/api/sys/vddcore"
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_vddcore_get(self):
         # test accessing get vdd core
         volt = self.get_vddcore()
@@ -343,7 +331,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             self.fail("get vddcore failed")
 
     # "/api/sys/vddcore/{#vddcore_value}"
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_vddcore_post(self):
         # save default value
         default_volt = self.get_vddcore()

--- a/tests2/tests/cloudripper/test_rest_mmc.py
+++ b/tests2/tests/cloudripper/test_rest_mmc.py
@@ -19,9 +19,7 @@
 import unittest
 
 import common.base_rest_mmc
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class RestMMCTest(common.base_rest_mmc.RestMMCTest):
     pass  # just run common tests

--- a/tests2/tests/cloudripper/test_sensor.py
+++ b/tests2/tests/cloudripper/test_sensor.py
@@ -27,10 +27,8 @@ from tests.cloudripper.test_data.sensors.sensor import (
     SCM_SENSORS,
     SMB_SENSORS,
 )
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class ScmSensorTest(SensorUtilTest, unittest.TestCase):
     def set_sensors_cmd(self):
         self.sensors_cmd = ["/usr/local/bin/sensor-util scm"]
@@ -85,7 +83,6 @@ class ScmSensorTest(SensorUtilTest, unittest.TestCase):
                     )
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class PsuSensorTest(SensorUtilTest, unittest.TestCase):
     @abstractmethod
     def get_psu_sensors(self):

--- a/tests2/tests/cloudripper/test_watchdog.py
+++ b/tests2/tests/cloudripper/test_watchdog.py
@@ -7,9 +7,7 @@
 import unittest
 
 from common.base_watchdog_test import WatchdogTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class WatchdogTest(WatchdogTest, unittest.TestCase):
     pass

--- a/tests2/tests/cmm/test_eeprom.py
+++ b/tests2/tests/cmm/test_eeprom.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_eeprom_test import CommonEepromTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class EepromTest(CommonEepromTest, unittest.TestCase):
     def set_eeprom_cmd(self):
         self.eeprom_cmd = ["/usr/bin/weutil"]

--- a/tests2/tests/cmm/test_emmc.py
+++ b/tests2/tests/cmm/test_emmc.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_emmc_test import BaseEmmcTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class CmmEmmcTest(BaseEmmcTest, unittest.TestCase):
     def set_emmc_mount_point(self):
         self.emmc_mountpoint = "/var/volatile/log"

--- a/tests2/tests/cmm/test_fans.py
+++ b/tests2/tests/cmm/test_fans.py
@@ -21,10 +21,8 @@ import unittest
 
 from common.base_fans_test import CommonShellBasedFansTest
 from utils.cit_logger import Logger
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FansTest(CommonShellBasedFansTest, unittest.TestCase):
     def setUp(self):
         Logger.start(name=self._testMethodName)

--- a/tests2/tests/cmm/test_gpio.py
+++ b/tests2/tests/cmm/test_gpio.py
@@ -21,10 +21,8 @@ import unittest
 
 from common.base_gpio_test import BaseGpioTest
 from tests.cmm.test_data.gpio.gpio import GPIOS
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class GpioTest(BaseGpioTest, unittest.TestCase):
     def set_gpios(self):
         self.gpios = GPIOS

--- a/tests2/tests/cmm/test_i2c.py
+++ b/tests2/tests/cmm/test_i2c.py
@@ -21,10 +21,8 @@ import unittest
 
 from common.base_i2c_test import BaseI2cTest
 from tests.cmm.test_data.i2c.i2c import plat_i2c_tree
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class CmmI2cTest(BaseI2cTest, unittest.TestCase):
     def load_golden_i2c_tree(self):
         self.i2c_tree = plat_i2c_tree

--- a/tests2/tests/cmm/test_obmc_mmc.py
+++ b/tests2/tests/cmm/test_obmc_mmc.py
@@ -19,9 +19,7 @@
 import unittest
 
 import common.base_obmc_mmc_test
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class LibObmcMmcTest(common.base_obmc_mmc_test.LibObmcMmcTest):
     pass  # just run common tests

--- a/tests2/tests/cmm/test_rest_mmc.py
+++ b/tests2/tests/cmm/test_rest_mmc.py
@@ -18,9 +18,7 @@
 import unittest
 
 import common.base_rest_mmc
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class RestMMCTest(common.base_rest_mmc.RestMMCTest):
     pass  # just run common tests

--- a/tests2/tests/cmm/test_watchdog.py
+++ b/tests2/tests/cmm/test_watchdog.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_watchdog_test import WatchdogTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class WatchdogTest(WatchdogTest, unittest.TestCase):
     def set_kill_watchdog_daemon_cmd(self):
         self.kill_watchdog_daemon_cmd = ["/usr/bin/killall fand"]

--- a/tests2/tests/elbert/test_eeprom.py
+++ b/tests2/tests/elbert/test_eeprom.py
@@ -24,10 +24,8 @@ import unittest
 from common.base_eeprom_test import CommonEepromTest
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class ELBERTEepromTest(CommonEepromTest):
     """
     Base Class for ELBERT EEPROM fields.

--- a/tests2/tests/elbert/test_emmc.py
+++ b/tests2/tests/elbert/test_emmc.py
@@ -20,13 +20,11 @@
 import unittest
 
 from common.base_emmc_test import BaseEmmcTest
-from utils.test_utils import qemu_check
 
 
 class ElbertEmmcTest(BaseEmmcTest, unittest.TestCase):
     def set_emmc_mount_point(self):
         self.emmc_mountpoint = "/mnt/data1"
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_emmc(self):
         super().test_emmc()

--- a/tests2/tests/elbert/test_fans.py
+++ b/tests2/tests/elbert/test_fans.py
@@ -22,10 +22,8 @@ import unittest
 
 from common.base_fans_test import CommonShellBasedFansTest
 from utils.cit_logger import Logger
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FansTest(CommonShellBasedFansTest, unittest.TestCase):
     def setUp(self):
         Logger.start(name=self._testMethodName)

--- a/tests2/tests/elbert/test_gpio.py
+++ b/tests2/tests/elbert/test_gpio.py
@@ -23,10 +23,8 @@ from common.base_gpio_test import BaseGpioTest
 from tests.elbert.test_data.gpio.gpio import GPIOS
 from tests.elbert.test_data.gpio.gpio import pim_gpios
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class GpioTest(BaseGpioTest, unittest.TestCase):
     def set_gpios(self):
         self.gpios = GPIOS

--- a/tests2/tests/elbert/test_i2c.py
+++ b/tests2/tests/elbert/test_i2c.py
@@ -33,7 +33,6 @@ from tests.elbert.test_data.i2c.i2c import (
     pim8ddm_secure_devices,
 )
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 # Map between PIM and SMBus channel
 pim_bus_p1 = [16, 17, 18, 23, 20, 21, 22, 19]
@@ -109,7 +108,6 @@ class ElbertI2cTest(BaseI2cTest, unittest.TestCase):
                         "{}: unexpected output: {}".format(name, output)
                     )
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_i2c_security(self):
         self.verify_secure_devices(secure_devices)
         pim_bus = self.get_pim_bus()
@@ -130,6 +128,5 @@ class ElbertI2cTest(BaseI2cTest, unittest.TestCase):
                 devices.append(("PIM{} {}".format(pim, name), bus, dev, dev_type))
             self.verify_secure_devices(devices)
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_i2c_tree(self):
         super().test_i2c_tree()

--- a/tests2/tests/elbert/test_libpal.py
+++ b/tests2/tests/elbert/test_libpal.py
@@ -19,24 +19,19 @@
 import unittest
 
 import common.base_libpal_test
-from utils.test_utils import qemu_check
 
 
 class LibPalTest(common.base_libpal_test.LibPalTest):
     PLATFORM_NAME = "elbert"
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_pal_is_fru_prsnt(self):
         super().test_pal_is_fru_prsnt()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_raw_read(self):
         super().test_sensor_raw_read()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_read(self):
         super().test_sensor_read()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_read_fru_not_present(self):
         super().test_sensor_read_fru_not_present()

--- a/tests2/tests/elbert/test_oob_eeprom.py
+++ b/tests2/tests/elbert/test_oob_eeprom.py
@@ -22,7 +22,6 @@ import unittest
 
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
 class OobEepromTest(unittest.TestCase):
@@ -34,7 +33,6 @@ class OobEepromTest(unittest.TestCase):
         Logger.info("Finished logging for {}".format(self._testMethodName))
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_eeprom_read(self):
         data = run_shell_cmd("{} read 0x0".format(self.eeprom_util)).split("\n")
         self.assertIn("0x0: 0xa8", data[0], "OOB EEPROM magic code missing")

--- a/tests2/tests/elbert/test_oob_mdio.py
+++ b/tests2/tests/elbert/test_oob_mdio.py
@@ -22,7 +22,6 @@ import unittest
 
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
 class OobMdioTest(unittest.TestCase):
@@ -34,7 +33,6 @@ class OobMdioTest(unittest.TestCase):
         Logger.info("Finished logging for {}".format(self._testMethodName))
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_mdio_read(self):
         # Test the IMP port state register
         data = run_shell_cmd("{} read8 0x0 0xe".format(self.mdio_util)).split("\n")

--- a/tests2/tests/elbert/test_rest_mmc.py
+++ b/tests2/tests/elbert/test_rest_mmc.py
@@ -19,9 +19,7 @@
 import unittest
 
 import common.base_rest_mmc
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class RestMMCTest(common.base_rest_mmc.RestMMCTest):
     pass  # just run common tests

--- a/tests2/tests/elbert/test_sensor_calibration.py
+++ b/tests2/tests/elbert/test_sensor_calibration.py
@@ -21,7 +21,6 @@ import unittest
 
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
 class SensorCalibrationTest(unittest.TestCase):
@@ -32,7 +31,6 @@ class SensorCalibrationTest(unittest.TestCase):
         Logger.info("Finished logging for {}".format(self._testMethodName))
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_max6581_tuned(self):
         # Test the IMP port state register
         data = run_shell_cmd("i2cget -f -y 4 0x4d 0x4a").split("\n")

--- a/tests2/tests/elbert/test_show_tech.py
+++ b/tests2/tests/elbert/test_show_tech.py
@@ -22,7 +22,6 @@ import unittest
 
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
 def collect_show_tech():
@@ -30,7 +29,6 @@ def collect_show_tech():
     return run_shell_cmd(show_tech_cmd)
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class ShowTechTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):

--- a/tests2/tests/elbert/test_system_airflow_config.py
+++ b/tests2/tests/elbert/test_system_airflow_config.py
@@ -21,7 +21,6 @@ import unittest
 
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
 class SystemAirflowConfigTest(unittest.TestCase):
@@ -63,7 +62,6 @@ class SystemAirflowConfigTest(unittest.TestCase):
                 psu_count += 1
         return psu_count
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_system_airflow_config(self):
         pim16q_count, pim8ddm_count = self.get_pim_count()
         psu_count = self.get_psu_count()

--- a/tests2/tests/elbert/test_watchdog.py
+++ b/tests2/tests/elbert/test_watchdog.py
@@ -7,9 +7,7 @@
 import unittest
 
 from common.base_watchdog_test import WatchdogTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class WatchdogTest(WatchdogTest, unittest.TestCase):
     pass

--- a/tests2/tests/fbtp/test_bios_util.py
+++ b/tests2/tests/fbtp/test_bios_util.py
@@ -20,12 +20,10 @@
 import unittest
 
 from common.base_bios_util_test import BaseBiosUtilTest
-from utils.test_utils import qemu_check
 
 FRU_LIST = ["mb"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class BiosUtilTest(BaseBiosUtilTest):
     def set_fru_list(self):
         self.fru_list = FRU_LIST

--- a/tests2/tests/fbtp/test_fans.py
+++ b/tests2/tests/fbtp/test_fans.py
@@ -21,7 +21,6 @@ import unittest
 
 from common.base_fans_test import CommonFanUtilBasedFansTest
 from utils.cit_logger import Logger
-from utils.test_utils import qemu_check
 
 
 class FansTest(CommonFanUtilBasedFansTest, unittest.TestCase):
@@ -38,6 +37,5 @@ class FansTest(CommonFanUtilBasedFansTest, unittest.TestCase):
         self.kill_fan_controller()
         self.start_fan_controller()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_fan_pwm_set(self):
         super().test_fan_pwm_set()

--- a/tests2/tests/fbtp/test_fru.py
+++ b/tests2/tests/fbtp/test_fru.py
@@ -21,10 +21,8 @@ import unittest
 
 from common.base_fru_test import CommonFruTest
 from utils.test_utils import check_fru_availability
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FruMbTest(CommonFruTest, unittest.TestCase):
     def setUp(self):
         self.fru_cmd = ["/usr/local/bin/fruid-util", "mb"]
@@ -56,7 +54,6 @@ class FruMbTest(CommonFruTest, unittest.TestCase):
         return product_fields
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FruRiserSlot2Test(CommonFruTest, unittest.TestCase):
     def setUp(self):
         self.fru = "riser_slot2"
@@ -100,7 +97,6 @@ class FruRiserSlot2Test(CommonFruTest, unittest.TestCase):
         super().test_fru_fields()
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FruRiserSlot3Test(FruRiserSlot2Test):
     def setUp(self):
         self.fru = "riser_slot3"

--- a/tests2/tests/fbtp/test_fw_util.py
+++ b/tests2/tests/fbtp/test_fw_util.py
@@ -20,12 +20,10 @@
 import unittest
 
 from common.base_fw_util_test import CommonFwUtilTest
-from utils.test_utils import qemu_check
 
 PLATFORM = "fbtp"
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FwUtilVersionTest(CommonFwUtilTest, unittest.TestCase):
     def set_platform(self):
         self.platform = PLATFORM

--- a/tests2/tests/fbtp/test_libpal.py
+++ b/tests2/tests/fbtp/test_libpal.py
@@ -19,7 +19,6 @@
 import unittest
 
 import common.base_libpal_test
-from utils.test_utils import qemu_check
 
 
 class LibPalTest(common.base_libpal_test.LibPalTest):
@@ -33,10 +32,8 @@ class LibPalTest(common.base_libpal_test.LibPalTest):
     def test_sensor_read(self):
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_pal_is_fru_prsnt(self):
         super().test_pal_is_fru_prsnt()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_read_fru_not_present(self):
         super().test_sensor_read_fru_not_present()

--- a/tests2/tests/fbtp/test_power_util.py
+++ b/tests2/tests/fbtp/test_power_util.py
@@ -20,12 +20,10 @@
 import unittest
 
 from common.base_power_util_test import BasePowerUtilTest
-from utils.test_utils import qemu_check
 
 slots = ["mb"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class PowerUtilTest(BasePowerUtilTest):
     def set_slots(self):
         self.slots = slots

--- a/tests2/tests/fbtp/test_rest_endpoint.py
+++ b/tests2/tests/fbtp/test_rest_endpoint.py
@@ -62,7 +62,6 @@ class RestEndpointTest(BaseRestEndpointTest, unittest.TestCase):
                 cls,
                 "test_restendpoint_{}".format(endpoint),
                 functools.partialmethod(
-                    unittest.skipIf(
                         qemu_check() and endpoint != "/api", "test env is QEMU, skipped"
                     )(verify_method),
                     endpoint,

--- a/tests2/tests/fbtp/test_sensor.py
+++ b/tests2/tests/fbtp/test_sensor.py
@@ -24,7 +24,6 @@ from common.base_sensor_test import SensorUtilTest
 from tests.fbtp.test_data.sensors.sensors import SENSORS
 from utils.cit_logger import Logger
 from utils.shell_util import run_cmd
-from utils.test_utils import qemu_check
 
 
 class MBSensorTest(SensorUtilTest, unittest.TestCase):
@@ -40,12 +39,10 @@ class MBSensorTest(SensorUtilTest, unittest.TestCase):
                 self.assertIn(key, result.keys(), "Missing sensor {}".format(key))
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class NicSensorTest(MBSensorTest):
     FRU_NAME = "nic"
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Riser2SensorTest(MBSensorTest):
     FRU_NAME = "riser_slot2"
 
@@ -63,11 +60,9 @@ class Riser2SensorTest(MBSensorTest):
                 self.assertIn(key, result.keys(), "Missing sensor {}".format(key))
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Riser3SensorTest(Riser2SensorTest):
     FRU_NAME = "riser_slot3"
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Riser4SensorTest(Riser2SensorTest):
     FRU_NAME = "riser_slot4"

--- a/tests2/tests/fbttn/test_bic.py
+++ b/tests2/tests/fbttn/test_bic.py
@@ -20,7 +20,6 @@
 import unittest
 
 from common.base_bic_test import CommonBicTest
-from utils.test_utils import qemu_check
 
 
 class BicTest(CommonBicTest, unittest.TestCase):
@@ -31,10 +30,8 @@ class BicTest(CommonBicTest, unittest.TestCase):
     def test_bic_mac(self):
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_bic_sdr(self, regex=None):
         super().test_bic_sdr(regex=regex)
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_bic_sensor(self, regex=None):
         super().test_bic_sensor(regex=regex)

--- a/tests2/tests/fbttn/test_bios_util.py
+++ b/tests2/tests/fbttn/test_bios_util.py
@@ -20,12 +20,10 @@
 import unittest
 
 from common.base_bios_util_test import BaseBiosUtilTest
-from utils.test_utils import qemu_check
 
 FRU_LIST = ["server"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class BiosUtilTest(BaseBiosUtilTest):
     def set_fru_list(self):
         self.fru_list = FRU_LIST

--- a/tests2/tests/fbttn/test_enclosure_util.py
+++ b/tests2/tests/fbttn/test_enclosure_util.py
@@ -20,18 +20,15 @@
 import unittest
 
 from common.base_enclosure_util_test import BaseEnclosureUtilTest
-from utils.test_utils import qemu_check
 
 
 class EnclosureUtilTest(BaseEnclosureUtilTest):
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def testHddStatus(self):
         """
         test enclosure-util --hdd-status and verify its output
         """
         super().testHddStatus()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def testHdd1Status(self):
         """
         test enclosure-util --hdd-status 1 and verify its output

--- a/tests2/tests/fbttn/test_fans.py
+++ b/tests2/tests/fbttn/test_fans.py
@@ -21,10 +21,8 @@ import unittest
 
 from common.base_fans_test import CommonFanUtilBasedFansTest
 from utils.cit_logger import Logger
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FansTest(CommonFanUtilBasedFansTest, unittest.TestCase):
     def setUp(self):
         Logger.start(name=self._testMethodName)

--- a/tests2/tests/fbttn/test_power_util.py
+++ b/tests2/tests/fbttn/test_power_util.py
@@ -20,13 +20,11 @@
 import unittest
 
 from common.base_power_util_test import BasePowerUtilTest
-from utils.test_utils import qemu_check
 
 
 slots = ["server"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class PowerUtilTest(BasePowerUtilTest):
     def set_slots(self):
         self.slots = slots

--- a/tests2/tests/fbttn/test_rest_endpoint.py
+++ b/tests2/tests/fbttn/test_rest_endpoint.py
@@ -62,7 +62,6 @@ class RestEndpointTest(BaseRestEndpointTest, unittest.TestCase):
                 cls,
                 "test_restendpoint_{}".format(endpoint),
                 functools.partialmethod(
-                    unittest.skipIf(
                         qemu_check() and endpoint != "/api", "test env is QEMU, skipped"
                     )(verify_method),
                     endpoint,

--- a/tests2/tests/fbttn/test_sensor.py
+++ b/tests2/tests/fbttn/test_sensor.py
@@ -21,10 +21,8 @@ import unittest
 
 from common.base_sensor_test import SensorUtilTest
 from tests.fbttn.test_data.sensors.sensors import SENSORS
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class MBSensorTest(SensorUtilTest, unittest.TestCase):
     FRU_NAME = "server"
 

--- a/tests2/tests/fby2/test_bic.py
+++ b/tests2/tests/fby2/test_bic.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_bic_test import CommonBicTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class BicSlot1Test(CommonBicTest, unittest.TestCase):
     def set_bic_cmd(self):
         self.bic_cmd = "/usr/bin/bic-util slot1"

--- a/tests2/tests/fby2/test_bios_util.py
+++ b/tests2/tests/fby2/test_bios_util.py
@@ -20,13 +20,11 @@
 import unittest
 
 from common.base_bios_util_test import BaseBiosUtilTest
-from utils.test_utils import qemu_check
 
 
 FRU_LIST = ["slot1", "slot2", "slot3", "slot4"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class BiosUtilTest(BaseBiosUtilTest):
     def set_fru_list(self):
         self.fru_list = FRU_LIST

--- a/tests2/tests/fby2/test_cpu_utilization.py
+++ b/tests2/tests/fby2/test_cpu_utilization.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_cpu_utilization_test import BaseCpuUtilizationTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class CpuUtilizationTest(BaseCpuUtilizationTest):
     def init_cpu_variables(self):
         """

--- a/tests2/tests/fby2/test_dimm_util.py
+++ b/tests2/tests/fby2/test_dimm_util.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_dimm_util_test import BaseDimmUtilTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class AllDimmUtilTest(BaseDimmUtilTest, unittest.TestCase):
     FRU = "all"
 

--- a/tests2/tests/fby2/test_fans.py
+++ b/tests2/tests/fby2/test_fans.py
@@ -21,10 +21,8 @@ import unittest
 
 from common.base_fans_test import CommonFanUtilBasedFansTest
 from utils.cit_logger import Logger
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FansTest(CommonFanUtilBasedFansTest, unittest.TestCase):
     def setUp(self):
         Logger.start(name=self._testMethodName)

--- a/tests2/tests/fby2/test_fru.py
+++ b/tests2/tests/fby2/test_fru.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_fru_test import CommonFruTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FruSpbTest(CommonFruTest, unittest.TestCase):
     def setUp(self):
         self.fru_cmd = ["/usr/local/bin/fruid-util", "spb"]

--- a/tests2/tests/fby2/test_gpio.py
+++ b/tests2/tests/fby2/test_gpio.py
@@ -21,13 +21,11 @@ import unittest
 
 from common.base_gpio_test import BaseGpioTest
 from tests.fby2.test_data.gpio.gpio import GPIOS
-from utils.test_utils import qemu_check
 
 
 class GpioTest(BaseGpioTest, unittest.TestCase):
     def set_gpios(self):
         self.gpios = GPIOS
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_gpios(self):
         super().test_gpios()

--- a/tests2/tests/fby2/test_libpal.py
+++ b/tests2/tests/fby2/test_libpal.py
@@ -19,7 +19,6 @@
 import unittest
 
 import common.base_libpal_test
-from utils.test_utils import qemu_check
 
 
 class LibPalTest(common.base_libpal_test.LibPalTest):
@@ -33,10 +32,8 @@ class LibPalTest(common.base_libpal_test.LibPalTest):
     def test_sensor_read(self):
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_pal_get_sensor_name(self):
         super().test_pal_get_sensor_name()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_pal_get_fru_sensor_list(self):
         super().test_pal_get_fru_sensor_list()

--- a/tests2/tests/fby2/test_power_util.py
+++ b/tests2/tests/fby2/test_power_util.py
@@ -20,13 +20,11 @@
 import unittest
 
 from common.base_power_util_test import BasePowerUtilTest
-from utils.test_utils import qemu_check
 
 
 slots = ["slot1", "slot2", "slot3", "slot4"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class PowerUtilTest(BasePowerUtilTest):
     def set_slots(self):
         self.slots = slots

--- a/tests2/tests/fby2/test_rest_endpoint.py
+++ b/tests2/tests/fby2/test_rest_endpoint.py
@@ -62,7 +62,6 @@ class RestEndpointTest(BaseRestEndpointTest, unittest.TestCase):
                 cls,
                 "test_restendpoint_{}".format(endpoint),
                 functools.partialmethod(
-                    unittest.skipIf(
                         qemu_check() and endpoint != "/api", "test env is QEMU, skipped"
                     )(verify_method),
                     endpoint,

--- a/tests2/tests/fby2/test_sensor.py
+++ b/tests2/tests/fby2/test_sensor.py
@@ -21,7 +21,6 @@ import unittest
 
 from common.base_sensor_test import SensorUtilTest
 from tests.fby2.test_data.sensors.sensors import SENSORS
-from utils.test_utils import qemu_check
 
 
 class Server1SensorTest(SensorUtilTest, unittest.TestCase):
@@ -30,7 +29,6 @@ class Server1SensorTest(SensorUtilTest, unittest.TestCase):
     def set_sensors_cmd(self):
         self.sensors_cmd = ["/usr/local/bin/sensor-util {}".format(self.FRU_NAME)]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_keys(self):
         result = self.get_parsed_result()
         for key in SENSORS[self.FRU_NAME]:

--- a/tests2/tests/fby3/test_bic.py
+++ b/tests2/tests/fby3/test_bic.py
@@ -20,12 +20,10 @@
 import unittest
 
 from common.base_bic_test import CommonBicTest
-from utils.test_utils import check_fru_availability, qemu_check
 
 slots = ["slot1", "slot2", "slot3", "slot4"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class BicTest(CommonBicTest, unittest.TestCase):
     def set_bic_cmd(self):
         pass

--- a/tests2/tests/fby3/test_bios_util.py
+++ b/tests2/tests/fby3/test_bios_util.py
@@ -20,12 +20,10 @@
 import unittest
 
 from common.base_bios_util_test import BaseBiosUtilTest
-from utils.test_utils import qemu_check
 
 FRU_LIST = ["slot1", "slot2", "slot3", "slot4"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class BiosUtilTest(BaseBiosUtilTest):
     def set_fru_list(self):
         self.fru_list = FRU_LIST

--- a/tests2/tests/fby3/test_cpu_utilization.py
+++ b/tests2/tests/fby3/test_cpu_utilization.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_cpu_utilization_test import BaseCpuUtilizationTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class CpuUtilizationTest(BaseCpuUtilizationTest):
     def init_cpu_variables(self):
         """

--- a/tests2/tests/fby3/test_fans.py
+++ b/tests2/tests/fby3/test_fans.py
@@ -21,10 +21,8 @@ import unittest
 
 from common.base_fans_test import CommonFanUtilBasedFansTest
 from utils.cit_logger import Logger
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FansTest(CommonFanUtilBasedFansTest, unittest.TestCase):
     def setUp(self):
         from pal import pal_get_tach_cnt, pal_get_pwm_cnt

--- a/tests2/tests/fby3/test_fru.py
+++ b/tests2/tests/fby3/test_fru.py
@@ -20,7 +20,6 @@
 import unittest
 
 from common.base_fru_test import CommonFruTest
-from utils.test_utils import qemu_check, check_fru_availability
 
 
 class FruSlot1Test(CommonFruTest, unittest.TestCase):
@@ -29,7 +28,6 @@ class FruSlot1Test(CommonFruTest, unittest.TestCase):
         self.fru_cmd = ["/usr/local/bin/fruid-util", "slot1"]
         self.fru_fields = {"chassis": 1, "product": 2, "board": 2}
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_fru_fields(self):
         if not check_fru_availability(self.fru):
             self.skipTest("skip test due to {} not available".format(self.fru))

--- a/tests2/tests/fby3/test_gpio.py
+++ b/tests2/tests/fby3/test_gpio.py
@@ -21,13 +21,11 @@ import unittest
 
 from common.base_gpio_test import BaseGpioTest
 from tests.fby3.test_data.gpio.gpio import GPIOS
-from utils.test_utils import qemu_check
 
 
 class GpioTest(BaseGpioTest, unittest.TestCase):
     def set_gpios(self):
         self.gpios = GPIOS
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_gpios(self):
         super().test_gpios()

--- a/tests2/tests/fby3/test_image_layout.py
+++ b/tests2/tests/fby3/test_image_layout.py
@@ -20,7 +20,6 @@
 import unittest
 
 from common.base_image_layout_test import BaseImageLayoutTest
-from utils.test_utils import qemu_check
 
 
 class ImageLayoutTest(BaseImageLayoutTest):
@@ -46,7 +45,6 @@ class ImageLayoutTest(BaseImageLayoutTest):
         },
     }
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_spi_1_mtd(self):
         """
         Test actual image layout on spi0.1 matches image meta data

--- a/tests2/tests/fby3/test_libpal.py
+++ b/tests2/tests/fby3/test_libpal.py
@@ -19,7 +19,6 @@
 import unittest
 
 import common.base_libpal_test
-from utils.test_utils import qemu_check
 
 
 class LibPalTest(common.base_libpal_test.LibPalTest):
@@ -33,6 +32,5 @@ class LibPalTest(common.base_libpal_test.LibPalTest):
     def test_sensor_read(self):
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_pal_get_sensor_name(self):
         super().test_pal_get_sensor_name()

--- a/tests2/tests/fby3/test_mboot.py
+++ b/tests2/tests/fby3/test_mboot.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_mboot_test import BaseMBootTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FBY3MBootTest(BaseMBootTest, unittest.TestCase):
     def set_check_list(self):
         self.check_list = {"spl", "key-store", "u-boot"}

--- a/tests2/tests/fby3/test_power_util.py
+++ b/tests2/tests/fby3/test_power_util.py
@@ -20,13 +20,11 @@
 import unittest
 
 from common.base_power_util_test import BasePowerUtilTest
-from utils.test_utils import qemu_check
 
 
 slots = ["slot1", "slot2", "slot3", "slot4"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class PowerUtilTest(BasePowerUtilTest):
     def set_slots(self):
         self.slots = slots

--- a/tests2/tests/fby3/test_rest_endpoint.py
+++ b/tests2/tests/fby3/test_rest_endpoint.py
@@ -62,7 +62,6 @@ class RestEndpointTest(BaseRestEndpointTest, unittest.TestCase):
                 cls,
                 "test_restendpoint_{}".format(endpoint),
                 functools.partialmethod(
-                    unittest.skipIf(
                         qemu_check() and endpoint != "/api", "test env is QEMU, skipped"
                     )(verify_method),
                     endpoint,

--- a/tests2/tests/fby3/test_sensor.py
+++ b/tests2/tests/fby3/test_sensor.py
@@ -21,7 +21,6 @@ import unittest
 
 from common.base_sensor_test import SensorUtilTest
 from tests.fby3.test_data.sensors.sensors import SENSORS
-from utils.test_utils import qemu_check, check_fru_availability
 
 
 class Slot1SensorTest(SensorUtilTest, unittest.TestCase):
@@ -30,7 +29,6 @@ class Slot1SensorTest(SensorUtilTest, unittest.TestCase):
     def set_sensors_cmd(self):
         self.sensors_cmd = ["/usr/local/bin/sensor-util {}".format(self.FRU_NAME)]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_keys(self):
         if not check_fru_availability(self.FRU_NAME):
             self.skipTest("skip test due to {} not available".format(self.FRU_NAME))

--- a/tests2/tests/fuji/test_bic.py
+++ b/tests2/tests/fuji/test_bic.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_bic_test import CommonBicTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FujiBicTest(CommonBicTest, unittest.TestCase):
     def set_bic_cmd(self):
         self.bic_cmd = "/usr/bin/bic-util scm"

--- a/tests2/tests/fuji/test_eeprom.py
+++ b/tests2/tests/fuji/test_eeprom.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_eeprom_test import CommonEepromTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class EepromTest(CommonEepromTest, unittest.TestCase):
     """
     Test for weutil

--- a/tests2/tests/fuji/test_emmc.py
+++ b/tests2/tests/fuji/test_emmc.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_emmc_test import BaseEmmcTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FujiEmmcTest(BaseEmmcTest, unittest.TestCase):
     def set_emmc_mount_point(self):
         self.emmc_mountpoint = "/mnt/data1"

--- a/tests2/tests/fuji/test_fans.py
+++ b/tests2/tests/fuji/test_fans.py
@@ -22,10 +22,8 @@ import unittest
 
 from common.base_fans_test import CommonShellBasedFansTest
 from utils.cit_logger import Logger
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FansTest(CommonShellBasedFansTest, unittest.TestCase):
     def setUp(self):
         Logger.start(name=self._testMethodName)

--- a/tests2/tests/fuji/test_fscd.py
+++ b/tests2/tests/fuji/test_fscd.py
@@ -24,10 +24,8 @@ from common.base_fscd_test import BaseFscdTest
 from tests.fuji.helper.libpal import pal_get_board_rev
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FscdTest(BaseFscdTest, unittest.TestCase):
 
     TEST_DATA_PATH = "/usr/local/bin/tests2/tests/fuji/test_data/fscd"

--- a/tests2/tests/fuji/test_host_mac.py
+++ b/tests2/tests/fuji/test_host_mac.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_host_mac_test import BaseHostMacTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class HostMacTest(BaseHostMacTest, unittest.TestCase):
     def set_host_mac(self):
         self.host_mac_cmd = ["/usr/local/bin/wedge_us_mac.sh"]

--- a/tests2/tests/fuji/test_i2c.py
+++ b/tests2/tests/fuji/test_i2c.py
@@ -21,10 +21,8 @@ import unittest
 
 from common.base_i2c_test import BaseI2cTest
 from tests.fuji.test_data.i2c.i2c import plat_i2c_tree
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class I2cTest(BaseI2cTest, unittest.TestCase):
     def load_golden_i2c_tree(self):
         self.i2c_tree = plat_i2c_tree

--- a/tests2/tests/fuji/test_libpal.py
+++ b/tests2/tests/fuji/test_libpal.py
@@ -20,24 +20,19 @@
 import unittest
 
 import common.base_libpal_test
-from utils.test_utils import qemu_check
 
 
 class LibPalTest(common.base_libpal_test.LibPalTest):
     PLATFORM_NAME = "fuji"
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_pal_is_fru_prsnt(self):
         super().test_pal_is_fru_prsnt()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_raw_read(self):
         super().test_sensor_raw_read()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_read(self):
         super().test_sensor_read()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_read_fru_not_present(self):
         super().test_sensor_read_fru_not_present()

--- a/tests2/tests/fuji/test_obmc_mmc.py
+++ b/tests2/tests/fuji/test_obmc_mmc.py
@@ -20,9 +20,7 @@
 import unittest
 
 import common.base_obmc_mmc_test
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class LibObmcMmcTest(common.base_obmc_mmc_test.LibObmcMmcTest):
     pass  # just run common tests

--- a/tests2/tests/fuji/test_psu.py
+++ b/tests2/tests/fuji/test_psu.py
@@ -21,10 +21,8 @@
 import unittest
 
 from common.base_psu_test import CommonPsuTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Psu1Test(CommonPsuTest, unittest.TestCase):
     def set_psu_cmd(self):
         self.psu_cmd = "/usr/bin/psu-util"

--- a/tests2/tests/fuji/test_rest_endpoint.py
+++ b/tests2/tests/fuji/test_rest_endpoint.py
@@ -47,7 +47,6 @@ from tests.fuji.test_data.sensors.sensor import (
 )
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
 class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
@@ -102,7 +101,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             "sensors",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys(self):
         self.set_endpoint_sys_attributes()
         self.verify_endpoint_attributes(
@@ -187,7 +185,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             else:
                 Logger.info("/api/sys/sensors: get PIM{} sensors None".format(pim + 1))
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_sensors(self):
         self.set_endpoint_sensors_attributes()
         self.verify_endpoint_attributes(
@@ -210,7 +207,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_scm_attributes(self):
         self.endpoint_fruid_scm_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_scm(self):
         self.set_endpoint_fruid_scm_attributes()
         self.verify_endpoint_attributes(
@@ -221,7 +217,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_smb_attributes(self):
         self.endpoint_fruid_smb_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_smb(self):
         self.set_endpoint_fruid_smb_attributes()
         self.verify_endpoint_attributes(
@@ -232,7 +227,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_mb_fruid_attributes(self):
         self.endpoint_mb_fruid_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_seutil_fruid(self):
         self.set_endpoint_mb_fruid_attributes()
         self.verify_endpoint_attributes(
@@ -243,7 +237,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fcm_top_attributes(self):
         self.endpoint_fruid_fcm_top_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fcm_top(self):
         self.set_endpoint_fruid_fcm_top_attributes()
         self.verify_endpoint_attributes(
@@ -254,7 +247,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fcm_bottom_attributes(self):
         self.endpoint_fruid_fcm_bottom_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fcm_bottom(self):
         self.set_endpoint_fruid_fcm_bottom_attributes()
         self.verify_endpoint_attributes(
@@ -266,7 +258,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan1_attributes(self):
         self.endpoint_fruid_fan1_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan1(self):
         self.set_endpoint_fruid_fan1_attributes()
         self.verify_endpoint_attributes(
@@ -277,7 +268,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan2_attributes(self):
         self.endpoint_fruid_fan2_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan2(self):
         self.set_endpoint_fruid_fan2_attributes()
         self.verify_endpoint_attributes(
@@ -288,7 +278,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan3_attributes(self):
         self.endpoint_fruid_fan3_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan3(self):
         self.set_endpoint_fruid_fan3_attributes()
         self.verify_endpoint_attributes(
@@ -299,7 +288,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan4_attributes(self):
         self.endpoint_fruid_fan4_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan4(self):
         self.set_endpoint_fruid_fan4_attributes()
         self.verify_endpoint_attributes(
@@ -310,7 +298,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan5_attributes(self):
         self.endpoint_fruid_fan5_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan5(self):
         self.set_endpoint_fruid_fan5_attributes()
         self.verify_endpoint_attributes(
@@ -321,7 +308,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan6_attributes(self):
         self.endpoint_fruid_fan6_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan6(self):
         self.set_endpoint_fruid_fan6_attributes()
         self.verify_endpoint_attributes(
@@ -332,7 +318,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan7_attributes(self):
         self.endpoint_fruid_fan7_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan7(self):
         self.set_endpoint_fruid_fan7_attributes()
         self.verify_endpoint_attributes(
@@ -343,7 +328,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan8_attributes(self):
         self.endpoint_fruid_fan8_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan8(self):
         self.set_endpoint_fruid_fan8_attributes()
         self.verify_endpoint_attributes(
@@ -354,7 +338,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_pim1_attributes(self):
         self.endpoint_fruid_pim1_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_pim1(self):
         self.set_endpoint_fruid_pim1_attributes()
         self.verify_endpoint_attributes(
@@ -365,7 +348,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_pim2_attributes(self):
         self.endpoint_fruid_pim2_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_pim2(self):
         self.set_endpoint_fruid_pim2_attributes()
         self.verify_endpoint_attributes(
@@ -376,7 +358,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_pim3_attributes(self):
         self.endpoint_fruid_pim3_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_pim3(self):
         self.set_endpoint_fruid_pim3_attributes()
         self.verify_endpoint_attributes(
@@ -387,7 +368,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_pim4_attributes(self):
         self.endpoint_fruid_pim4_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_pim4(self):
         self.set_endpoint_fruid_pim4_attributes()
         self.verify_endpoint_attributes(
@@ -398,7 +378,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_pim5_attributes(self):
         self.endpoint_fruid_pim5_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_pim5(self):
         self.set_endpoint_fruid_pim5_attributes()
         self.verify_endpoint_attributes(
@@ -409,7 +388,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_pim6_attributes(self):
         self.endpoint_fruid_pim6_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_pim6(self):
         self.set_endpoint_fruid_pim6_attributes()
         self.verify_endpoint_attributes(
@@ -420,7 +398,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_pim7_attributes(self):
         self.endpoint_fruid_pim7_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_pim7(self):
         self.set_endpoint_fruid_pim7_attributes()
         self.verify_endpoint_attributes(
@@ -431,7 +408,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_pim8_attributes(self):
         self.endpoint_fruid_pim8_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_pim8(self):
         self.set_endpoint_fruid_pim8_attributes()
         self.verify_endpoint_attributes(
@@ -587,7 +563,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             "PIM9",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_piminfo(self):
         self.set_endpoint_piminfo_attributes()
         self.verify_endpoint_attributes(

--- a/tests2/tests/fuji/test_sensor.py
+++ b/tests2/tests/fuji/test_sensor.py
@@ -46,10 +46,8 @@ from tests.fuji.test_data.sensors.sensor import (
     SCM_SENSORS,
     SMB_SENSORS,
 )
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class ScmSensorTest(SensorUtilTest, unittest.TestCase):
     def set_sensors_cmd(self):
         self.sensors_cmd = ["/usr/local/bin/sensor-util scm"]
@@ -91,7 +89,6 @@ class ScmSensorTest(SensorUtilTest, unittest.TestCase):
                 )
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class PimSensorTest(SensorUtilTest, unittest.TestCase):
     @abstractmethod
     def get_pim_sensors(self):
@@ -331,7 +328,6 @@ class Pim8SensorTest(PimSensorTest, unittest.TestCase):
         super().base_test_pim_temp_sensor_range()
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class PsuSensorTest(SensorUtilTest, unittest.TestCase):
     @abstractmethod
     def get_psu_sensors(self):

--- a/tests2/tests/fuji/test_watchdog.py
+++ b/tests2/tests/fuji/test_watchdog.py
@@ -7,9 +7,7 @@
 import unittest
 
 from common.base_watchdog_test import WatchdogTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class WatchdogTest(WatchdogTest, unittest.TestCase):
     pass

--- a/tests2/tests/grandcanyon/test_cpu_utilization.py
+++ b/tests2/tests/grandcanyon/test_cpu_utilization.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_cpu_utilization_test import BaseCpuUtilizationTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class CpuUtilizationTest(BaseCpuUtilizationTest):
     def init_cpu_variables(self):
         """

--- a/tests2/tests/grandcanyon/test_gpios.py
+++ b/tests2/tests/grandcanyon/test_gpios.py
@@ -21,13 +21,11 @@ import unittest
 
 from common.base_gpio_test import BaseGpioTest
 from tests.grandcanyon.test_data.gpio.gpio import GPIOS
-from utils.test_utils import qemu_check
 
 
 class GpioTest(BaseGpioTest, unittest.TestCase):
     def set_gpios(self):
         self.gpios = GPIOS
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_gpios(self):
         super().test_gpios()

--- a/tests2/tests/minipack/test_bic.py
+++ b/tests2/tests/minipack/test_bic.py
@@ -20,17 +20,14 @@
 import unittest
 
 from common.base_bic_test import CommonBicTest
-from utils.test_utils import qemu_check
 
 
 class MinipackBicTest(CommonBicTest, unittest.TestCase):
     def set_bic_cmd(self):
         self.bic_cmd = "/usr/bin/bic-util scm"
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_bic_sdr(self, regex=None):
         super().test_bic_sdr(regex=regex)
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_bic_sensor(self, regex=None):
         super().test_bic_sensor(regex=regex)

--- a/tests2/tests/minipack/test_eeprom.py
+++ b/tests2/tests/minipack/test_eeprom.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_eeprom_test import CommonEepromTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class EepromTest(CommonEepromTest, unittest.TestCase):
     """
     Test for weutil

--- a/tests2/tests/minipack/test_emmc.py
+++ b/tests2/tests/minipack/test_emmc.py
@@ -20,13 +20,11 @@
 import unittest
 
 from common.base_emmc_test import BaseEmmcTest
-from utils.test_utils import qemu_check
 
 
 class MinipackEmmcTest(BaseEmmcTest, unittest.TestCase):
     def set_emmc_mount_point(self):
         self.emmc_mountpoint = "/mnt/data1"
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_emmc(self):
         super().test_emmc()

--- a/tests2/tests/minipack/test_fans.py
+++ b/tests2/tests/minipack/test_fans.py
@@ -22,10 +22,8 @@ import unittest
 
 from common.base_fans_test import CommonShellBasedFansTest
 from utils.cit_logger import Logger
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FansTest(CommonShellBasedFansTest, unittest.TestCase):
     def setUp(self):
         Logger.start(name=self._testMethodName)

--- a/tests2/tests/minipack/test_host_mac.py
+++ b/tests2/tests/minipack/test_host_mac.py
@@ -20,17 +20,14 @@
 import unittest
 
 from common.base_host_mac_test import BaseHostMacTest
-from utils.test_utils import qemu_check
 
 
 class HostMacTest(BaseHostMacTest, unittest.TestCase):
     def set_host_mac(self):
         self.host_mac_cmd = ["/usr/local/bin/wedge_us_mac.sh"]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_host_mac(self):
         super().test_host_mac()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_host_mac_zero_test(self):
         super().test_host_mac_zero_test()

--- a/tests2/tests/minipack/test_i2c.py
+++ b/tests2/tests/minipack/test_i2c.py
@@ -21,13 +21,11 @@ import unittest
 
 from common.base_i2c_test import BaseI2cTest
 from tests.minipack.test_data.i2c.i2c import plat_i2c_tree
-from utils.test_utils import qemu_check
 
 
 class MinipackI2cTest(BaseI2cTest, unittest.TestCase):
     def load_golden_i2c_tree(self):
         self.i2c_tree = plat_i2c_tree
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_i2c_tree(self):
         super().test_i2c_tree()

--- a/tests2/tests/minipack/test_kernel_abi.py
+++ b/tests2/tests/minipack/test_kernel_abi.py
@@ -20,7 +20,6 @@
 import unittest
 
 from common.base_kernel_abi_test import BaseKernelABITest
-from utils.test_utils import qemu_check
 
 
 class KernelABITest(BaseKernelABITest, unittest.TestCase):
@@ -28,6 +27,5 @@ class KernelABITest(BaseKernelABITest, unittest.TestCase):
         self.platform_dep_list = []
         pass
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_kernel_path_exists(self):
         super().test_kernel_path_exists()

--- a/tests2/tests/minipack/test_libpal.py
+++ b/tests2/tests/minipack/test_libpal.py
@@ -20,24 +20,19 @@
 import unittest
 
 import common.base_libpal_test
-from utils.test_utils import qemu_check
 
 
 class LibPalTest(common.base_libpal_test.LibPalTest):
     PLATFORM_NAME = "minipack"
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_pal_is_fru_prsnt(self):
         super().test_pal_is_fru_prsnt()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_read_fru_not_present(self):
         super().test_sensor_read_fru_not_present()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_read(self):
         super().test_sensor_read()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_raw_read(self):
         super().test_sensor_raw_read()

--- a/tests2/tests/minipack/test_obmc_mmc.py
+++ b/tests2/tests/minipack/test_obmc_mmc.py
@@ -20,10 +20,8 @@
 import unittest
 
 import common.base_obmc_mmc_test
-from utils.test_utils import qemu_check
 
 
 class LibObmcMmcTest(common.base_obmc_mmc_test.LibObmcMmcTest):
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_list_devices(self):
         super().test_list_devices()

--- a/tests2/tests/minipack/test_rest_endpoint.py
+++ b/tests2/tests/minipack/test_rest_endpoint.py
@@ -21,7 +21,6 @@ import unittest
 
 from common.base_rest_endpoint_test import FbossRestEndpointTest
 from tests.minipack.test_data.sensors.sensors import SENSORS
-from utils.test_utils import qemu_check
 
 
 class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
@@ -89,7 +88,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_scm_attributes(self):
         self.endpoint_fruid_scm_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_scm(self):
         self.set_endpoint_fruid_scm_attributes()
         self.verify_endpoint_attributes(
@@ -109,7 +107,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             "pim8",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_pim_present(self):
         self.set_endpoint_pim_presence_attributes()
         self.verify_endpoint_attributes(
@@ -129,7 +126,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             "PIM8",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_piminfo(self):
         self.set_endpoint_piminfo_attributes()
         self.verify_endpoint_attributes(
@@ -137,7 +133,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
         )
 
     # "/api/sys/pimserial"
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_pimserial(self):
         self.set_endpoint_piminfo_attributes()
         self.verify_endpoint_attributes(
@@ -146,7 +141,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
         )
 
     # "/api/sys/pimstatus"
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_pimstatus(self):
         self.set_endpoint_pim_presence_attributes()
         self.verify_endpoint_attributes(
@@ -158,7 +152,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_seutil_fruid_attributes(self):
         self.endpoint_seutil_fruid_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_mb_seutil_fruid(self):
         self.set_endpoint_seutil_fruid_attributes()
         self.verify_endpoint_attributes(
@@ -205,7 +198,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             "8",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_firmware_info_pim(self):
         self.set_endpoint_firmware_info_pim_attributes()
         self.verify_endpoint_attributes(
@@ -218,7 +210,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
         # scm attribute <-> version map.
         self.endpoint_firmware_info_scm_attributes = ["1"]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_firmware_info_scm(self):
         self.set_endpoint_firmware_info_scm_attributes()
         self.verify_endpoint_attributes(
@@ -227,7 +218,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
         )
 
     # "/api/sys/firmware_info_all"
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_firmware_all(self):
         self.set_endpoint_firmware_info_all_attributes()
         self.verify_endpoint_attributes(
@@ -239,7 +229,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
         self.endpoint_system_led_info_attrb = ["sys", "smb", "psu", "fan"]
 
     # "/api/sys/system_led_info"
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_system_led_info(self):
         self.set_endpoint_system_led_info_attributes()
         self.verify_endpoint_attributes(
@@ -247,7 +236,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
         )
 
     # "/api/sys/pimdetails"
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_pimdetails(self):
         self.set_endpoint_firmware_info_pim_attributes()
         self.verify_endpoint_attributes(

--- a/tests2/tests/minipack/test_rest_mmc.py
+++ b/tests2/tests/minipack/test_rest_mmc.py
@@ -18,9 +18,7 @@
 import unittest
 
 import common.base_rest_mmc
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class RestMMCTest(common.base_rest_mmc.RestMMCTest):
     pass  # just run common tests

--- a/tests2/tests/minipack/test_sensor.py
+++ b/tests2/tests/minipack/test_sensor.py
@@ -37,10 +37,8 @@ from tests.minipack.test_data.sensors.sensors import (
     SCM_SENSORS,
     SMB_SENSORS,
 )
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class ScmSensorTest(SensorUtilTest, unittest.TestCase):
     def set_sensors_cmd(self):
         self.sensors_cmd = ["/usr/local/bin/sensor-util scm"]
@@ -79,7 +77,6 @@ class ScmSensorTest(SensorUtilTest, unittest.TestCase):
                 )
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class PimSensorTest(SensorUtilTest, unittest.TestCase):
     @abstractmethod
     def get_pim_sensors(self):
@@ -238,7 +235,6 @@ class Pim8SensorTest(PimSensorTest, unittest.TestCase):
         super().base_test_pim_temp_sensor_range()
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class PsuSensorTest(SensorUtilTest, unittest.TestCase):
     @abstractmethod
     def get_psu_sensors(self):

--- a/tests2/tests/minipack/test_watchdog.py
+++ b/tests2/tests/minipack/test_watchdog.py
@@ -7,9 +7,7 @@
 import unittest
 
 from common.base_watchdog_test import WatchdogTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class WatchdogTest(WatchdogTest, unittest.TestCase):
     pass

--- a/tests2/tests/wedge400/test_bic.py
+++ b/tests2/tests/wedge400/test_bic.py
@@ -20,17 +20,14 @@
 import unittest
 
 from common.base_bic_test import CommonBicTest
-from utils.test_utils import qemu_check
 
 
 class BicTest(CommonBicTest, unittest.TestCase):
     def set_bic_cmd(self):
         self.bic_cmd = "/usr/bin/bic-util scm"
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_bic_sdr(self, regex=None):
         super().test_bic_sdr(regex=regex)
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_bic_sensor(self, regex=None):
         super().test_bic_sensor(regex=regex)

--- a/tests2/tests/wedge400/test_eeprom.py
+++ b/tests2/tests/wedge400/test_eeprom.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_eeprom_test import CommonEepromTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class EepromTest(CommonEepromTest, unittest.TestCase):
     """
     Test for weutil

--- a/tests2/tests/wedge400/test_fans.py
+++ b/tests2/tests/wedge400/test_fans.py
@@ -22,10 +22,8 @@ import unittest
 
 from common.base_fans_test import CommonShellBasedFansTest
 from utils.cit_logger import Logger
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FansTest(CommonShellBasedFansTest, unittest.TestCase):
     def setUp(self):
         Logger.start(name=self._testMethodName)

--- a/tests2/tests/wedge400/test_fscd.py
+++ b/tests2/tests/wedge400/test_fscd.py
@@ -24,10 +24,8 @@ from common.base_fscd_test import BaseFscdTest
 from tests.wedge400.helper.libpal import pal_get_board_type
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class FscdTest(BaseFscdTest, unittest.TestCase):
 
     TEST_DATA_PATH = "/usr/local/bin/tests2/tests/wedge400/test_data/fscd"

--- a/tests2/tests/wedge400/test_fw_env.py
+++ b/tests2/tests/wedge400/test_fw_env.py
@@ -20,9 +20,7 @@
 import unittest
 
 from common.base_fw_env_test import BaseFwEnvTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class TestFwEnv(BaseFwEnvTest, unittest.TestCase):
     pass

--- a/tests2/tests/wedge400/test_gibraltar.py
+++ b/tests2/tests/wedge400/test_gibraltar.py
@@ -21,10 +21,8 @@ import unittest
 
 from common.base_switch_test import BaseSwitchTest
 from tests.wedge400.helper.libpal import pal_get_board_type
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class GibraltarTest(BaseSwitchTest, unittest.TestCase):
     """
     Test for smb_syscpld node gb_turn_on

--- a/tests2/tests/wedge400/test_host_mac.py
+++ b/tests2/tests/wedge400/test_host_mac.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_host_mac_test import BaseHostMacTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class HostMacTest(BaseHostMacTest, unittest.TestCase):
     def set_host_mac(self):
         self.host_mac_cmd = ["/usr/local/bin/wedge_us_mac.sh"]

--- a/tests2/tests/wedge400/test_kernel_abi.py
+++ b/tests2/tests/wedge400/test_kernel_abi.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_kernel_abi_test import BaseKernelABITest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class KernelABITest(BaseKernelABITest, unittest.TestCase):
     def set_platform_specific_paths(self):
         self.platform_dep_list = []

--- a/tests2/tests/wedge400/test_libpal.py
+++ b/tests2/tests/wedge400/test_libpal.py
@@ -20,24 +20,19 @@
 import unittest
 
 import common.base_libpal_test
-from utils.test_utils import qemu_check
 
 
 class LibPalTest(common.base_libpal_test.LibPalTest):
     PLATFORM_NAME = "wedge400"
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_pal_is_fru_prsnt(self):
         super().test_pal_is_fru_prsnt()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_raw_read(self):
         super().test_sensor_raw_read()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_read(self):
         super().test_sensor_read()
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_sensor_read_fru_not_present(self):
         super().test_sensor_read_fru_not_present()

--- a/tests2/tests/wedge400/test_obmc_mmc.py
+++ b/tests2/tests/wedge400/test_obmc_mmc.py
@@ -20,9 +20,7 @@
 import unittest
 
 import common.base_obmc_mmc_test
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class LibObmcMmcTest(common.base_obmc_mmc_test.LibObmcMmcTest):
     pass  # just run common tests

--- a/tests2/tests/wedge400/test_pem.py
+++ b/tests2/tests/wedge400/test_pem.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_pem_test import PemInfoTest, PemEepromTest, PemBlackboxTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Pem1InfoTest(PemInfoTest, unittest.TestCase):
     """
     Test for pem1 info
@@ -34,7 +32,6 @@ class Pem1InfoTest(PemInfoTest, unittest.TestCase):
         self.pem_id = 1
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Pem2InfoTest(PemInfoTest, unittest.TestCase):
     """
     Test for pem2 info
@@ -45,7 +42,6 @@ class Pem2InfoTest(PemInfoTest, unittest.TestCase):
         self.pem_id = 2
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Pem1EepromTest(PemEepromTest, unittest.TestCase):
     """
     Test for pem1 Eeprom
@@ -62,7 +58,6 @@ class Pem1EepromTest(PemEepromTest, unittest.TestCase):
         self.location_on_fabric = ["PEM"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Pem2EepromTest(PemEepromTest, unittest.TestCase):
     """
     Test for pem2 Eeprom
@@ -79,7 +74,6 @@ class Pem2EepromTest(PemEepromTest, unittest.TestCase):
         self.location_on_fabric = ["PEM"]
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Pem1BlackboxTest(PemBlackboxTest, unittest.TestCase):
     """
     Test for pem1 Blackbox
@@ -90,7 +84,6 @@ class Pem1BlackboxTest(PemBlackboxTest, unittest.TestCase):
         self.pem_id = 1
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Pem2BlackboxTest(PemBlackboxTest, unittest.TestCase):
     """
     Test for pem2 Blackbox

--- a/tests2/tests/wedge400/test_psu.py
+++ b/tests2/tests/wedge400/test_psu.py
@@ -21,17 +21,14 @@
 import unittest
 
 from common.base_psu_test import CommonPsuTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Psu1Test(CommonPsuTest, unittest.TestCase):
     def set_psu_cmd(self):
         self.psu_cmd = "/usr/bin/psu-util"
         self.psu_id = 1
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class Psu2Test(CommonPsuTest, unittest.TestCase):
     def set_psu_cmd(self):
         self.psu_cmd = "/usr/bin/psu-util"

--- a/tests2/tests/wedge400/test_rest_endpoint.py
+++ b/tests2/tests/wedge400/test_rest_endpoint.py
@@ -40,7 +40,6 @@ from tests.wedge400.test_data.sensors.sensors import (
 )
 from utils.cit_logger import Logger
 from utils.shell_util import run_shell_cmd
-from utils.test_utils import qemu_check
 
 
 class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
@@ -86,7 +85,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             self.endpoint_sys_attrb.append("vddcore")
             self.endpoint_sys_attrb.append("switch_reset")
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys(self):
         self.set_endpoint_sys_attributes()
         self.verify_endpoint_attributes(
@@ -133,7 +131,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
         if pal_detect_power_supply_present(BoardRevision.POWER_MODULE_PSU1) == "psu2":
             self.endpoint_sensors_attrb += PSU2_SENSORS
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_sensors(self):
         self.set_endpoint_sensors_attributes()
         self.verify_endpoint_attributes(
@@ -152,7 +149,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_scm_attributes(self):
         self.endpoint_fruid_scm_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_scm(self):
         self.set_endpoint_fruid_scm_attributes()
         self.verify_endpoint_attributes(
@@ -163,7 +159,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_mb_fruid_attributes(self):
         self.endpoint_mb_fruid_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_seutil_fruid(self):
         self.set_endpoint_mb_fruid_attributes()
         self.verify_endpoint_attributes(
@@ -174,7 +169,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fcm_attributes(self):
         self.endpoint_fruid_fcm_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fcm(self):
         self.set_endpoint_fruid_fcm_attributes()
         self.verify_endpoint_attributes(
@@ -185,7 +179,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan1_attributes(self):
         self.endpoint_fruid_fan1_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan1(self):
         self.set_endpoint_fruid_fan1_attributes()
         self.verify_endpoint_attributes(
@@ -196,7 +189,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan2_attributes(self):
         self.endpoint_fruid_fan2_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan2(self):
         self.set_endpoint_fruid_fan2_attributes()
         self.verify_endpoint_attributes(
@@ -207,7 +199,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan3_attributes(self):
         self.endpoint_fruid_fan3_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan3(self):
         self.set_endpoint_fruid_fan3_attributes()
         self.verify_endpoint_attributes(
@@ -218,7 +209,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fruid_fan4_attributes(self):
         self.endpoint_fruid_fan4_attrb = self.FRUID_ATTRIBUTES
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_fruid_fan4(self):
         self.set_endpoint_fruid_fan4_attributes()
         self.verify_endpoint_attributes(
@@ -229,7 +219,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_scm_presence_attributes(self):
         self.endpoint_scm_presence = ["scm"]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_scm_present(self):
         self.set_endpoint_scm_presence_attributes()
         self.verify_endpoint_attributes(
@@ -240,7 +229,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_psu_presence_attributes(self):
         self.endpoint_psu_presence = ["psu1", "psu2"]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_psu_present(self):
         self.set_endpoint_psu_presence_attributes()
         self.verify_endpoint_attributes(
@@ -251,7 +239,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_fan_presence_attributes(self):
         self.endpoint_fan_presence = ["fan1", "fan2", "fan3", "fan4"]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_fan_present(self):
         self.set_endpoint_fan_presence_attributes()
         self.verify_endpoint_attributes(
@@ -267,7 +254,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             "SMBCPLD",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_firmware_info_cpld(self):
         self.set_endpoint_firmware_info_cpld_attributes()
         self.verify_endpoint_attributes(
@@ -279,7 +265,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_firmware_info_fpga_attributes(self):
         self.endpoint_firmware_info_fpga_attributes = ["DOMFPGA1", "DOMFPGA2"]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_firmware_info_fpga(self):
         self.set_endpoint_firmware_info_fpga_attributes()
         self.verify_endpoint_attributes(
@@ -300,7 +285,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             "BIOS Version",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_firmware_info_scm(self):
         self.set_endpoint_firmware_info_scm_attributes()
         self.verify_endpoint_attributes(
@@ -331,7 +315,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             "P1V05 VR Version",
         ]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_firmware_info_all(self):
         self.set_endpoint_firmware_info_all_attributes()
         self.verify_endpoint_attributes(
@@ -365,7 +348,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
         return True
 
     # "/api/sys/vddcore"
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_vddcore_get(self):
         platform_type = pal_get_board_type()
         # Wedge400 need to skip vddcore
@@ -378,7 +360,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             self.fail("get vddcore failed")
 
     # "/api/sys/vddcore/{#vddcore_value}"
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_vddcore_post(self):
         platform_type = pal_get_board_type()
         # Wedge400 need to skip vddcore
@@ -415,7 +396,6 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
     def set_endpoint_api_sys_switch_reset_attributes(self):
         self.endpoint_switch_reset_attributes = ["cycle_reset", "only_reset"]
 
-    @unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
     def test_endpoint_api_sys_switch_reset(self):
         platform_type = pal_get_board_type()
         # Wedge400 need to skip vddcore

--- a/tests2/tests/wedge400/test_rest_mmc.py
+++ b/tests2/tests/wedge400/test_rest_mmc.py
@@ -19,9 +19,7 @@
 import unittest
 
 import common.base_rest_mmc
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class RestMMCTest(common.base_rest_mmc.RestMMCTest):
     pass  # just run common tests

--- a/tests2/tests/wedge400/test_rest_modbus_cmd.py
+++ b/tests2/tests/wedge400/test_rest_modbus_cmd.py
@@ -20,9 +20,7 @@
 import unittest
 
 import common.base_rest_modbus_cmd
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class RestModbusCmdTest(common.base_rest_modbus_cmd.RestModbusCmdTest):
     pass  # just run common tests

--- a/tests2/tests/wedge400/test_sensor.py
+++ b/tests2/tests/wedge400/test_sensor.py
@@ -36,10 +36,8 @@ from tests.wedge400.test_data.sensors.sensors import (
     SMB_SENSORS_W400CEVT,
     SMB_SENSORS_W400CEVT2,
 )
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class ScmSensorTest(SensorUtilTest, unittest.TestCase):
     def set_sensors_cmd(self):
         self.sensors_cmd = ["/usr/local/bin/sensor-util scm"]

--- a/tests2/tests/wedge400/test_usb_host.py
+++ b/tests2/tests/wedge400/test_usb_host.py
@@ -20,10 +20,8 @@
 import unittest
 
 from common.base_usb_host_test import BaseUSBHostTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class USBHostDeviceTest(BaseUSBHostTest, unittest.TestCase):
     def set_usb_devices(self):
         self.usb_devices = [

--- a/tests2/tests/wedge400/test_watchdog.py
+++ b/tests2/tests/wedge400/test_watchdog.py
@@ -7,9 +7,7 @@
 import unittest
 
 from common.base_watchdog_test import WatchdogTest
-from utils.test_utils import qemu_check
 
 
-@unittest.skipIf(qemu_check(), "test env is QEMU, skipped")
 class WatchdogTest(WatchdogTest, unittest.TestCase):
     pass

--- a/tests2/utils/test_utils.py
+++ b/tests2/utils/test_utils.py
@@ -52,7 +52,6 @@ def check_fru_availability(fru: str) -> bool:
     return False
 
 
-def qemu_check():
     return os.path.exists("/usr/local/bin/tests2/dummy_qemu")
 
 


### PR DESCRIPTION
Summary:
I used this script to rewrite each file to remove the skipIf decorators if possible. I'll look at the CircleCI results, and then add additional tests to the qemu_denylist.txt file to replace these filters.

We still have some qemu_check usage within test cases to perform different test behavior in some cases.

```
import os

def rewrite_file(path):
    lines = [line for line in open(path, 'r') if "unittest.skipIf" not in line]

    # Remove qemu_check import if unused
    tmp = [line for line in lines if "qemu_check" not in line]
    if len(lines) - len(tmp) == 1:
        lines = tmp

    text = ''.join(lines)
    with open(path, 'w') as f:
        f.truncate(len(text))
        f.write(text)

def yield_file_paths(directory):
    for dir, _, files in os.walk("tests2"):
        for file in files:
            rel_path = os.path.join(dir, file)
            yield rel_path

if __name__ == '__main__':
    for path in yield_file_paths("tests2"):
        rewrite_file(path)
```

Test Plan:
Watching CircleCI results.