### PR TITLE
tests2: Add --denylist option to cit_runner.py

### DIFF
--- a/tools/circle-ci/cit_test_wrapper.py
+++ b/tools/circle-ci/cit_test_wrapper.py
@@ -207,7 +207,8 @@ if __name__ == "__main__":
     if not args.test:
         status, out, err = testWrapper.run_cmd_on_oob(
             "python3 /usr/local/bin/tests2/cit_runner.py"
-            + f" --platform {platform} --list-tests"
+            f" --platform {platform} --list-tests"
+            f" --denylist /usr/local/bin/tests2/qemu_denylist.txt"
         )
         if status != 0:
             sys.exit(1)
@@ -222,6 +223,7 @@ if __name__ == "__main__":
     for test in testWrapper.tests:
         status, out, err = testWrapper.run_cmd_on_oob(
             f"python3 /usr/local/bin/tests2/cit_runner.py --run-test {test}"
+            f" --denylist /usr/local/bin/tests2/qemu_denylist.txt"
         )
         if status != 0:
             fail_count += 1


### PR DESCRIPTION
Summary:
`cit_runner.py` checks for the existence of the file `/usr/local/bin/tests2/dummy_qemu` to determine if we're in QEMU. That, in turn, determines whether we use `qemu_denylist.txt` to filter out tests.

This turns out to not work well in Netcastle, because even in QEMU Netcastle runs, we run `cit_runner.py` outside of QEMU to list tests. We need a better way to specify when to use the denylist.

I think the simplest thing is to just make it an optional argument: in CircleCI and QEMU Netcastle runs, we can specify the denylist path in the invocation, and everywhere else we can just ignore the denylist argument.

Test Plan:
Watching CircleCI to make sure it doesn't break.