### PR TITLE
tests2: Add --tmpfs argument to ptest-runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,14 +56,14 @@ jobs:
                   MACHINE: qemux86
               user: root
         resource_class: 2xlarge
-        working_directory: /mnt/ramdisk
+        working_directory: /tmp/job/project
         steps:
             - attach_workspace:
                 at: /tmp/job
             - run:
                 name: Build qemux86 and run package-test within
                 command: |
-                    python3 /tmp/job/project/tests2/ptest-runner -b /tmp/job/project/build --verbose
+                    python3 tests2/ptest-runner -b build --tmpfs /mnt/ramdisk --verbose
     qemu-cit:
         parameters:
             machine:

--- a/tests2/ptest-runner
+++ b/tests2/ptest-runner
@@ -153,7 +153,8 @@ def main(args):
     deploy = args.build + "/tmp/deploy/images/qemux86"
     rootfs_zip = deploy + "/qemux86-image-qemux86.tar.bz2"
     rootfs_zip = os.path.abspath(rootfs_zip)
-    rootfs = "./rootfs"
+    rootfs = args.tmpfs if args.tmpfs else deploy
+    rootfs += "/rootfs"
     if os.path.isdir(rootfs):
         shutil.rmtree(rootfs)
     os.makedirs(rootfs)
@@ -162,12 +163,12 @@ def main(args):
     subprocess.check_call(
         ["mkdir", "-p", rootfs + "/dev/shm", rootfs + "/tmp"]
     )  # fake shm,tmp for flake8
-    if not os.path.exists("/.dockerenv"):
+    if not args.tmpfs:
         base_cmd = ["unshare", "--mount", "--map-root-user", "chroot", rootfs]
         init_steps = ["mount -t tmpfs -o size=512m tmpfs /dev/shm"]
     else:
-        # It's not necessary to mount /dev/shm as tmpfs in CircleCI because we
-        # unpack the rootfs within /mnt/ramdisk, which is already a tmpfs.
+        # If we unpacked the rootfs within an existing tmpfs, then we don't have
+        # to mount /dev/shm as a tmpfs.
         base_cmd = ["sudo", "chroot", rootfs]
         init_steps = []
 
@@ -206,6 +207,10 @@ parser.add_argument(
     help="Use an existing build directory instead of building one (For debugging)",
     dest="build",
     default=None,
+)
+parser.add_argument(
+    "--tmpfs",
+    help="Unpack the rootfs in an existing tmpfs instead of trying to mount ones",
 )
 parser.add_argument(
     "--force-rebuild",


### PR DESCRIPTION
Summary:
In #177, I changed ptest-runner to unpack the rootfs in the working directory, and then forced CircleCI to cd to /mnt/ramdisk, so that the rootfs would get unpacked in a tmpfs.

Instead, we can just specify the tmpfs directory as an optional argument for this situation, and keep the old behavior for everything else. This avoids leaving the rootfs sitting around in people's working directories too.

Test Plan:
Verifying CircleCI and Sandcastle ptest runs pass.