### PR TITLE
circleci: Make sure build dir is created for qemux86

### DIFF
--- a/tools/circle-ci/check-build-required
+++ b/tools/circle-ci/check-build-required
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-if [ "$MACHINE" == "qemux86" ]; then
-  exit 0
-fi
-
 # Source openbmc setup script.
 source "$(dirname "${BASH_SOURCE[0]}")/../../openbmc-init-build-env" \
     "$MACHINE" build
+
+if [ "$MACHINE" == "qemux86" ]; then
+  exit 0
+fi
 
 # List of subdirectories that might contain machine-specific code.
 MACHINE_METAS="\


### PR DESCRIPTION
Summary:
In "Force qemux86 builds unconditionally", I didn't realize that I needed to source the build environment script (effectively initializing the build directory), because the next script `download-sstate-cache` depends on this build directory being setup.

I accidentally added a short-circuiting exit that skipped initializing the build directory.

This is also because I didn't properly test the previous diff!

Test Plan:
Now that I'm actually submitting through Github, I'll make sure that CircleCI passes.