### PR TITLE
tests2: Update busybox chattr usage

### DIFF
--- a/tests2/common/base_busybox_syntax_test.py
+++ b/tests2/common/base_busybox_syntax_test.py
@@ -98,6 +98,7 @@ KNOWN_USAGE_STRINGS = {
         "chattr [-R] [-+=AacDdijsStTu] [-v VERSION] [FILE]...",
         "chattr [-pRVf] [-+=aAcCdDeijPsStTu] [-v version] files...",  # BusyBox 1.30.1
         "chattr [-pRVf] [-+=aAcCdDeijPsStTuF] [-v version] files...",  # BusyBox 1.31.0
+        "chattr [-pRVf] [-+=aAcCdDeijPsStTuFx] [-v version] files...",
         "chattr [-R] [-v VERSION] [-+=AacDdijsStTu] FILE...",  # BusyBox 1.31.1
     ],
     "chgrp": ["chgrp [-RhLHP]... GROUP FILE..."],


### PR DESCRIPTION
Summary:
Recent lf-dunfell update added a new version of chattr.

Test Plan:
Make sure QEMU CIT runs in CircleCI pass.