### PR TITLE
googletest: Change branch from master to main

### DIFF
--- a/meta-facebook/meta-backports/dunfell/recipes-test/googletest/googletest_git.bbappend
+++ b/meta-facebook/meta-backports/dunfell/recipes-test/googletest/googletest_git.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/google/googletest.git;branch=main;protocol=https"


### PR DESCRIPTION
Summary:
Switch from master to main didn't leave master branch around, need this to fix fetch errors in CircleCI until we get the fix backported by yocto maintainers.

Once [this](https://git.openembedded.org/meta-openembedded/commit/meta-oe/recipes-test/googletest/googletest_git.bb?id=eab5e822a91ad95cf0e7d2406ba3ab5304748713) yocto change is backported to dunfell, we can remove this recipe.

Test Plan:
Verified that the SRC_URI changed appropriately, and watching CircleCI jobs:

```
$ bitbake -e googletest | grep SRC_URI=\"
SRC_URI="git://github.com/google/googletest.git;branch=main;protocol=https"
```