### PR TITLE
tests2: Disable failing wedge400 and fuji tests in QEMU

### DIFF
--- a/tests2/qemu_denylist.txt
+++ b/tests2/qemu_denylist.txt
@@ -16,6 +16,11 @@ tests.fby2.test_libpal.LibPalTest.test_pal_get_platform_name
 tests.fuji.test_fw_env.TestFwEnv.test_fw_setenv
 tests.fuji.test_interface.InterfaceTest.test_usb0_v6_interface
 tests.fuji.test_process_running.ProcessRunningTest.test_installed_processes
+tests.fuji.test_sensor.SmbSensorTest.test_smb_sensor_keys
+tests.wedge400.test_sensor.Fan1SensorTest.test_fan1_sensor_keys
+tests.wedge400.test_sensor.Fan2SensorTest.test_fan2_sensor_keys
+tests.wedge400.test_sensor.Fan3SensorTest.test_fan3_sensor_keys
+tests.wedge400.test_sensor.Fan4SensorTest.test_fan4_sensor_keys
 tests.yamp.test_eeprom.PIM1EepromTest.test_extended_mac_base
 tests.yamp.test_eeprom.PIM1EepromTest.test_product_name
 tests.yamp.test_eeprom.PIM1EepromTest.test_product_part_number


### PR DESCRIPTION
Summary:
A couple tests started failing in QEMU recently. I'm not sure why they started failing in QEMU, because the output for the fan-util command doesn't seem to have changed recently, but whatever the root cause is, it's probably best to just disable them for now.

Test Plan:
Verifying CircleCI and Netcastle QEMU jobs pass.