### PR TITLE
meta-aspeed: Add SRCPV to kernel and u-boot recipes

### DIFF
--- a/meta-aspeed/recipes-bsp/u-boot/u-boot_2019.04.bb
+++ b/meta-aspeed/recipes-bsp/u-boot/u-boot_2019.04.bb
@@ -3,7 +3,7 @@ require u-boot-common.inc
 
 DEPENDS += "bc-native dtc-native"
 
-PV = "v2019.04"
+PV = "v2019.04${SRCPV}"
 OVERRIDES += ":bld-uboot"
 
 SRCBRANCH = "openbmc/helium/v2019.04"

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.0.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.0.bb
@@ -4,7 +4,7 @@ SRCREV = "AUTOINC"
 SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
           "
 
-LINUX_VERSION ?= "5.0.3"
+LINUX_VERSION ?= "5.0.3${SRCPV}"
 LINUX_VERSION_EXTENSION ?= "-aspeed"
 
 PR = "r1"

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.10.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.10.bb
@@ -4,7 +4,7 @@ SRCREV = "AUTOINC"
 SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
           "
 
-LINUX_VERSION ?= "5.10.23"
+LINUX_VERSION ?= "5.10.23${SRCPV}"
 LINUX_VERSION_EXTENSION ?= "-aspeed"
 
 PR = "r1"

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.15.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.15.bb
@@ -4,7 +4,7 @@ SRCREV = "AUTOINC"
 SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
           "
 
-LINUX_VERSION ?= "5.15.25"
+LINUX_VERSION ?= "5.15.27${SRCPV}"
 LINUX_VERSION_EXTENSION ?= "-aspeed"
 
 PR = "r1"

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.6.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.6.bb
@@ -4,7 +4,7 @@ SRCREV = "AUTOINC"
 SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
           "
 
-LINUX_VERSION ?= "5.6.19"
+LINUX_VERSION ?= "5.6.19${SRCPV}"
 LINUX_VERSION_EXTENSION ?= "-aspeed"
 
 PR = "r1"


### PR DESCRIPTION
Summary:
I think because of
[this](https://lore.kernel.org/all/CANNYZj8mR7Ov9w+=b3mv1QVLc_0G9Nusj1D3ZmzYq3yn3pA5MA@mail.gmail.com/T/)
commit in bitbake, we now need to include SRCPV in AUTOREV recipes.

I also incremented the kernel version from .25 to .27, because the
revision has increased. I think it's expected that we need to manually
increment the kernel version every so often with AUTOREV.

Test Plan: Watching netcastle build jobs for kirkstone platforms.

Reviewers: goldenbug

Subscribers: 

Tasks: 

Tags: 


Differential Revision: https://phabricator.intern.facebook.com/D37801554