### PR TITLE
github: meta-aspeed: Replace AUTOINC with fixed SRCREV

### DIFF
--- a/meta-aspeed/recipes-bsp/u-boot/u-boot-fw-utils_2019.04.bb
+++ b/meta-aspeed/recipes-bsp/u-boot/u-boot-fw-utils_2019.04.bb
@@ -1,5 +1,7 @@
 require u-boot-common.inc
 
+SRCREV = "dce130c9826afe8b9c445b30784d0da94c37493b"
+
 PV = "v2019.04"
 SRC_URI += "file://fw_env.config \
             file://fw_env.config.64k \

--- a/meta-aspeed/recipes-bsp/u-boot/u-boot-tools_2019.04.bb
+++ b/meta-aspeed/recipes-bsp/u-boot/u-boot-tools_2019.04.bb
@@ -1,6 +1,7 @@
 require u-boot-common.inc
 require u-boot-tools.inc
 
+SRCREV = "dce130c9826afe8b9c445b30784d0da94c37493b"
 PV = "v2019.04"
 SRCBRANCH = "openbmc/helium/v2019.04"
 

--- a/meta-aspeed/recipes-bsp/u-boot/u-boot_2019.04.bb
+++ b/meta-aspeed/recipes-bsp/u-boot/u-boot_2019.04.bb
@@ -3,6 +3,8 @@ require u-boot-common.inc
 
 DEPENDS += "bc-native dtc-native"
 
+SRCREV = "dce130c9826afe8b9c445b30784d0da94c37493b"
+
 PV = "v2019.04"
 OVERRIDES += ":bld-uboot"
 

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.0.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.0.bb
@@ -1,5 +1,5 @@
 SRCBRANCH = "dev-5.0"
-SRCREV = "AUTOINC"
+SRCREV = "f0f75fc33db7ac5b80fa0e6009f12ff7bd5995eb"
 
 SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
           "

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.10.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.10.bb
@@ -1,5 +1,5 @@
 SRCBRANCH = "dev-5.10"
-SRCREV = "AUTOINC"
+SRCREV = "671fbc8b281a7a10650382802bfde2aa9ebc80d8"
 
 SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
           "

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.15.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.15.bb
@@ -1,5 +1,5 @@
 SRCBRANCH = "dev-5.15"
-SRCREV = "AUTOINC"
+SRCREV = "82cc9dc5fcd3f91f508b751e257ba3bdfe53a236"
 
 SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
           "

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.6.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.6.bb
@@ -1,5 +1,5 @@
 SRCBRANCH = "dev-5.6"
-SRCREV = "AUTOINC"
+SRCREV = "720a51d83cfa8ff2ed57501005e035b43d8b3585"
 
 SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
           "


### PR DESCRIPTION
Summary:
tl;dr

Our internal repository builds linux and u-boot as `file://` URI’s.
Out Github repository builds linux and u-boot as `git://` URI's.

Test Plan:
Exporting to Github and looking at CircleCI jobs.

Also, `cp -r openbmc/github/meta-aspeed fbopenbmc/` produces this diff: P520363269

Reviewed By: peterdelevoryas

