### PR TITLE
github: Fix PV in kirkstone kernel/u-boot recipes

### DIFF
--- a/github/linux-aspeed-src.inc
+++ b/github/linux-aspeed-src.inc
@@ -1,0 +1,6 @@
+SRCBRANCH = "dev-${LINUX_VERSION_MAJOR}.${LINUX_VERSION_MINOR}"
+SRCREV = "AUTOINC"
+SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
+          "
+PV = "${LINUX_VERSION}+git${SRCPV}"
+S = "${WORKDIR}/git"

--- a/github/u-boot-src.inc
+++ b/github/u-boot-src.inc
@@ -1,0 +1,1 @@
+PV = "v${UBOOT_MAJOR}.${UBOOT_MINOR}+git${SRCPV}"

--- a/meta-aspeed/recipes-bsp/u-boot/u-boot-common.inc
+++ b/meta-aspeed/recipes-bsp/u-boot/u-boot-common.inc
@@ -14,6 +14,9 @@ SRC_URI = "git://github.com/facebook/openbmc-uboot.git;branch=${SRCBRANCH};proto
 SRCREV = "AUTOINC"
 S = "${WORKDIR}/git"
 
+UBOOT_MAJOR = "${@d.getVar('SRCBRANCH').split('/')[2].split('.')[0]}"
+UBOOT_MINOR = "${@d.getVar('SRCBRANCH').split('/')[2].split('.')[1].split('+')[0]}"
+
 # u-boot v2020.01, which is used in Dunfell and above, has different settings
 # than earlier u-boot versions.  Set these variables so that we can use older
 # u-boot versions with newer Yocto versions.
@@ -129,3 +132,5 @@ do_deploy:append:bld-uboot() {
     ln -sf ${UBOOT_RECOVERY_IMAGE} ${UBOOT_RECOVERY_BINARYNAME}
   fi
 }
+
+require u-boot-src.inc

--- a/meta-aspeed/recipes-bsp/u-boot/u-boot-src.inc
+++ b/meta-aspeed/recipes-bsp/u-boot/u-boot-src.inc
@@ -1,0 +1,1 @@
+PV = "v${UBOOT_MAJOR}.${UBOOT_MINOR}+git${SRCPV}"

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed-src.inc
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed-src.inc
@@ -1,0 +1,6 @@
+SRCBRANCH = "dev-${LINUX_VERSION_MAJOR}.${LINUX_VERSION_MINOR}"
+SRCREV = "AUTOINC"
+SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
+          "
+PV = "${LINUX_VERSION}+git${SRCPV}"
+S = "${WORKDIR}/git"

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed.inc
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed.inc
@@ -1,3 +1,8 @@
+LINUX_VERSION_MAJOR ?= "${@d.getVar('LINUX_VERSION').split('.')[0]}"
+LINUX_VERSION_MINOR ?= "${@d.getVar('LINUX_VERSION').split('.')[1]}"
+
+require linux-aspeed-src.inc
+
 DESCRIPTION = "Linux Kernel for Aspeed"
 SECTION = "kernel"
 LICENSE = "GPLv2"

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_4.1.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_4.1.bb
@@ -1,7 +1,5 @@
-SRCBRANCH = "dev-4.1"
-SRCREV = "AUTOINC"
 
-SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
+SRC_URI = "file://linux-aspeed-4.1 \
           "
 
 LINUX_VERSION ?= "4.1.51"
@@ -13,7 +11,7 @@ PV = "${LINUX_VERSION}"
 
 include linux-aspeed.inc
 
-S = "${WORKDIR}/git"
+S = "${WORKDIR}/linux-aspeed-4.1"
 
 do_configure:prepend() {
     # in kernel.bbclass::kernel_do_configure(), the code only copies defconfig to

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.%.bbappend
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.%.bbappend
@@ -1,0 +1,17 @@
+SRC_URI += "\
+    ${@bb.utils.contains('MACHINE_FEATURES', 'mtd-ubifs', \
+                         'file://ubifs.scc file://ubifs.cfg', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'emmc', \
+        bb.utils.contains('MACHINE_FEATURES', 'emmc-ext4', \
+                           'file://emmc-ext4.scc file://emmc-ext4.cfg', \
+                           'file://emmc-btrfs.scc file://emmc-btrfs.cfg', d), \
+        '', d)} \
+    "
+
+KERNEL_FEATURES:append = " \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'mtd-ubifs', \
+                         'ubifs.scc', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'emmc', \
+        bb.utils.contains('MACHINE_FEATURES', 'emmc-ext4', \
+                             'emmc-ext4.scc', 'emmc-btrfs.scc', d), '', d)} \
+    "

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.0.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.0.bb
@@ -1,7 +1,4 @@
-SRCBRANCH = "dev-5.0"
-SRCREV = "AUTOINC"
-
-SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
+SRC_URI = "file://linux-aspeed-5.0 \
           "
 
 LINUX_VERSION ?= "5.0.3"
@@ -18,4 +15,4 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}gcc:do_populate_sysroot"
 KCONFIG_MODE="--alldefconfig"
 
-S = "${WORKDIR}/git"
+S = "${WORKDIR}/linux-aspeed-5.0"

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.10.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.10.bb
@@ -1,7 +1,4 @@
-SRCBRANCH = "dev-5.10"
-SRCREV = "AUTOINC"
-
-SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
+SRC_URI = "file://linux-aspeed-5.10 \
           "
 
 LINUX_VERSION ?= "5.10.23"
@@ -18,7 +15,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}gcc:do_populate_sysroot"
 KCONFIG_MODE="--alldefconfig"
 
-S = "${WORKDIR}/git"
+S = "${WORKDIR}/linux-aspeed-5.10"
 
 #
 # Note: below fixup is needed to bitbake linux kernel 5.2 or higher kernel

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.15.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.15.bb
@@ -1,7 +1,4 @@
-SRCBRANCH = "dev-5.15"
-SRCREV = "AUTOINC"
-
-SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
+SRC_URI = "file://linux-aspeed-5.15 \
           "
 
 LINUX_VERSION ?= "5.15.27"
@@ -18,7 +15,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}gcc:do_populate_sysroot"
 KCONFIG_MODE="--alldefconfig"
 
-S = "${WORKDIR}/git"
+S = "${WORKDIR}/linux-aspeed-5.15"
 
 #
 # Note: below fixup is needed to bitbake linux kernel 5.2 or higher kernel

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.6.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_5.6.bb
@@ -1,7 +1,4 @@
-SRCBRANCH = "dev-5.6"
-SRCREV = "AUTOINC"
-
-SRC_URI = "git://github.com/facebook/openbmc-linux.git;branch=${SRCBRANCH};protocol=https \
+SRC_URI = "file://linux-aspeed-5.6 \
           "
 
 LINUX_VERSION ?= "5.6.19"
@@ -18,7 +15,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}gcc:do_populate_sysroot"
 KCONFIG_MODE="--alldefconfig"
 
-S = "${WORKDIR}/git"
+S = "${WORKDIR}/linux-aspeed-5.6"
 
 #
 # Note: below fixup is needed to bitbake linux kernel 5.2 or higher kernel

--- a/meta-facebook/meta-clearcreek/conf/machine/clearcreek.conf
+++ b/meta-facebook/meta-clearcreek/conf/machine/clearcreek.conf
@@ -17,7 +17,7 @@ PREFERRED_VERSION_u-boot-tools = "v2019.04"
 PREFERRED_VERSION_u-boot-tools-native = "v2019.04"
 PREFERRED_VERSION_nativesdk-u-boot-tools = "v2019.04"
 
-PREFERRED_VERSION_linux-aspeed = "5.6.19"
+PREFERRED_VERSION_linux-aspeed = "5.6.%"
 PREFERRED_VERSION_libwatchdog = "0.2"
 
 require conf/machine/include/fb-compute.inc

--- a/meta-facebook/meta-elbert/conf/machine/elbertvboot.conf
+++ b/meta-facebook/meta-elbert/conf/machine/elbertvboot.conf
@@ -10,7 +10,7 @@ UBOOT_CONFIG_BASE = "fbobmc-ast-g6_defconfig"
 
 KERNEL_DEVICETREE = "aspeed-bmc-facebook-elbertvboot.dtb"
 
-PREFERRED_VERSION_linux-aspeed = "5.6.19"
+PREFERRED_VERSION_linux-aspeed = "5.6.%"
 
 PREFERRED_VERSION_u-boot = "v2019.04"
 PREFERRED_VERSION_u-boot-tools = "v2019.04"

--- a/meta-facebook/meta-fbal/conf/machine/angelslanding.conf
+++ b/meta-facebook/meta-fbal/conf/machine/angelslanding.conf
@@ -17,7 +17,7 @@ PREFERRED_VERSION_u-boot-tools = "v2019.04"
 PREFERRED_VERSION_u-boot-tools-native = "v2019.04"
 PREFERRED_VERSION_nativesdk-u-boot-tools = "v2019.04"
 
-PREFERRED_VERSION_linux-aspeed = "5.0.3"
+PREFERRED_VERSION_linux-aspeed = "5.0.%"
 PREFERRED_VERSION_libwatchdog = "0.2"
 PREFERRED_VERSION_bios-util = "0.2"
 PREFERRED_VERSION_asd = "1.4.3"

--- a/meta-facebook/meta-fbep/conf/machine/emeraldpools.conf
+++ b/meta-facebook/meta-fbep/conf/machine/emeraldpools.conf
@@ -17,7 +17,7 @@ PREFERRED_VERSION_u-boot-tools = "v2019.04"
 PREFERRED_VERSION_u-boot-tools-native = "v2019.04"
 PREFERRED_VERSION_nativesdk-u-boot-tools = "v2019.04"
 
-PREFERRED_VERSION_linux-aspeed = "5.0.3"
+PREFERRED_VERSION_linux-aspeed = "5.0.%"
 PREFERRED_VERSION_libwatchdog = "0.2"
 
 require conf/machine/include/fb-compute.inc

--- a/meta-facebook/meta-fbsp/conf/machine/sonorapass.conf
+++ b/meta-facebook/meta-fbsp/conf/machine/sonorapass.conf
@@ -19,7 +19,7 @@ PREFERRED_VERSION_u-boot-fw-utils-cross = "v2019.01"
 PREFERRED_VERSION_bios-util = "0.2"
 PREFERRED_VERSION_at93cx6-util = "0.1"
 PREFERRED_VERSION_libwatchdog = "0.1"
-PREFERRED_VERSION_linux-aspeed = "5.0.3"
+PREFERRED_VERSION_linux-aspeed = "5.0.%"
 PREFERRED_VERSION_libwatchdog = "0.2"
 
 require conf/machine/include/fb-compute.inc

--- a/meta-facebook/meta-fbtp/conf/machine/fbtp-next.conf
+++ b/meta-facebook/meta-fbtp/conf/machine/fbtp-next.conf
@@ -14,7 +14,7 @@ PREFERRED_VERSION_bios-util = "0.2"
 PREFERRED_VERSION_at93cx6-util = "0.1"
 
 KERNEL_DEVICETREE = "aspeed-bmc-facebook-tiogapass.dtb"
-PREFERRED_VERSION_linux-aspeed = "5.0.3"
+PREFERRED_VERSION_linux-aspeed = "5.0.%"
 PREFERRED_VERSION_libwatchdog = "0.2"
 
 KERNEL_IMAGETYPE = "zImage"

--- a/meta-facebook/meta-fbtp/conf/machine/fbtp.conf
+++ b/meta-facebook/meta-fbtp/conf/machine/fbtp.conf
@@ -15,7 +15,7 @@ PREFERRED_VERSION_libwatchdog = "0.1"
 # Comment above and uncomment below to
 # test build with linux-kernel 5.0.
 # KERNEL_DEVICETREE = "aspeed-bmc-facebook-tiogapass.dtb"
-# PREFERRED_VERSION_linux-aspeed = "5.0.3"
+# PREFERRED_VERSION_linux-aspeed = "5.0.%"
 # PREFERRED_VERSION_libwatchdog = "0.2"
 
 KERNEL_IMAGETYPE = "zImage"

--- a/meta-facebook/meta-fby2/meta-fby2-kernel/conf/machine/fby2-kernel.conf
+++ b/meta-facebook/meta-fby2/meta-fby2-kernel/conf/machine/fby2-kernel.conf
@@ -8,7 +8,7 @@ UBOOT_MACHINE:fby2-kernel = "fby2_config"
 KERNEL_IMAGETYPE = "zImage"
 
 KERNEL_DEVICETREE = "aspeed-bmc-facebook-yosemitev2.dtb"
-PREFERRED_VERSION_linux-aspeed = "5.0.3"
+PREFERRED_VERSION_linux-aspeed = "5.0.%"
 
 PREFERRED_VERSION_u-boot = "v2016.07"
 PREFERRED_VERSION_u-boot-mkimage = "v2016.07"

--- a/meta-facebook/meta-fby2/meta-fby2-nd/conf/machine/northdome.conf
+++ b/meta-facebook/meta-fby2/meta-fby2-nd/conf/machine/northdome.conf
@@ -21,7 +21,7 @@ PREFERRED_VERSION_bic-util = "0.1"
 
 PREFERRED_VERSION_bios-util = "0.2"
 
-PREFERRED_VERSION_linux-aspeed = "5.6.19"
+PREFERRED_VERSION_linux-aspeed = "5.6.%"
 KERNEL_IMAGETYPE = "zImage"
 
 require conf/machine/include/ast2520.inc

--- a/meta-facebook/meta-fby3/conf/machine/fby3.conf
+++ b/meta-facebook/meta-fby3/conf/machine/fby3.conf
@@ -20,7 +20,7 @@ PREFERRED_VERSION_bios-util = "0.2"
 PREFERRED_VERSION_libwatchdog = "0.2"
 PREFERRED_VERSION_libbic = "0.1"
 PREFERRED_VERSION_bic-util = "0.1"
-PREFERRED_VERSION_linux-aspeed = "5.0.3"
+PREFERRED_VERSION_linux-aspeed = "5.0.%"
 PREFERRED_VERSION_asd = "1.4.3"
 
 require conf/machine/include/fb-bic.inc

--- a/meta-facebook/meta-minipack/conf/machine/minipack.conf
+++ b/meta-facebook/meta-minipack/conf/machine/minipack.conf
@@ -14,7 +14,7 @@ KERNEL_IMAGETYPE = "zImage"
 #     * if you want to downgrade kernel to v4.1, please remove the line
 #       (or comment it out).
 #   - PREFERRED_VERSION_linux-aspeed:
-#     * set it to the version you like: 4.1.51, 5.0.3 or 5.3.8.
+#     * set it to the version you like: 4.1.51, 5.0.% or 5.3.8.
 #   - PREFERRED_VERSION_libwatchdog:
 #     * version "0.1" for kernel v4.1.
 #     * version "0.2" for kernel v4.17 or higher versions.

--- a/meta-facebook/meta-yamp/conf/machine/yamp.conf
+++ b/meta-facebook/meta-yamp/conf/machine/yamp.conf
@@ -14,7 +14,7 @@ UBOOT_MACHINE:yamp = "fbyamp_config"
 #     * if you want to downgrade kernel to v4.1, please remove the line
 #       (or comment it out).
 #   - PREFERRED_VERSION_linux-aspeed:
-#     * set it to the version you like: 4.1.51, 4.18.16 or 5.0.3.
+#     * set it to the version you like: 4.1.51, 4.18.16 or 5.0.%.
 #   - PREFERRED_VERSION_libwatchdog:
 #     * version "0.1" for kernel v4.1.
 #     * version "0.2" for kernel v4.17 or higher versions.


### PR DESCRIPTION
Summary:
tl;dr

Our internal repository builds linux and u-boot as `file://` URI’s.
Out Github repository builds linux and u-boot as `git://` URI's.

Test Plan: Exporting this diff to Github after the configerator diff to enable `meta-facebook` mappings and watching CircleCI jobs.

Reviewed By: peterdelevoryas

