### PR TITLE
github: Add workflow for building QEMU

### DIFF
--- a/.github/actions/build_qemu/Dockerfile
+++ b/.github/actions/build_qemu/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+RUN ln -snf /usr/share/zoneinfo/US/Pacific /etc/localtime && echo "US/Pacific" > /etc/timezone
+RUN apt update
+RUN apt install -y \
+    git make gcc ninja-build pkg-config libglib2.0-dev libpixman-1-dev python3.8-venv \
+    chrpath cpio diffstat g++ gawk liblz4-tool wget zstd locales
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/build_qemu/action.yml
+++ b/.github/actions/build_qemu/action.yml
@@ -1,0 +1,5 @@
+name: 'Build QEMU'
+description: 'Build QEMU, using bitbake to fetch the source code'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/build_qemu/entrypoint.sh
+++ b/.github/actions/build_qemu/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+git config --global --add safe.directory $PWD
+git config --global user.name "openbmc"
+git config --global user.email "openbmc@meta.com"
+./sync_yocto.sh
+. ./openbmc-init-build-env greatlakes build
+touch conf/sanity.conf
+devtool modify qemu-system-native
+cd workspace/sources/qemu-system-native
+./configure \
+    --target-list=aarch64-softmmu \
+    --with-git-submodules=ignore \
+    --without-default-features \
+    --disable-debug-info \
+    --disable-install-blobs \
+    --enable-strip \
+    --enable-tpm \
+    --enable-slirp=internal
+ninja -C build
+./build/qemu-system-aarch64 -h

--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -1,0 +1,57 @@
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag'
+        required: True
+name: Create QEMU release
+jobs:
+  build_qemu_executable:
+    name: Build QEMU
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout OpenBMC
+        uses: actions/checkout@v3
+      - name: Build QEMU
+        uses: ./.github/actions/build_qemu
+      - name: Save qemu-system-aarch64 build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: qemu-system-aarch64
+          path: ./build/workspace/sources/qemu-system-native/build/qemu-system-aarch64
+  create_release:
+    name: Create release
+    needs: [build_qemu_executable]
+    runs-on: ubuntu-20.04
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          release_name: ${{ github.event.inputs.tag }}
+          draft: false
+          prerelease: false
+  upload_qemu_executable:
+    name: Upload QEMU binary to release assets
+    needs: [build_qemu_executable, create_release]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download QEMU binary
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: qemu-system-aarch64
+      - name: Add qemu-system-aarch64 release artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.download.outputs.download-path }}/qemu-system-aarch64
+          asset_name: qemu-system-aarch64
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
Summary:
We need a way to build QEMU releases for CircleCI, so I'm porting the workflow I had from https://github.com/facebook/openbmc-qemu.

Test Plan:
Verified running the workflow in my fork: https://fburl.com/fpqhirpf