### PR TITLE
fuji: fix the origin value of the retry

### DIFF
--- a/meta-facebook/meta-fuji/recipes-fuji/platform-lib/files/pal/pal-pim.c
+++ b/meta-facebook/meta-fuji/recipes-fuji/platform-lib/files/pal/pal-pim.c
@@ -106,7 +106,7 @@ static int pim_dom_fpga_indirect_write(int fru, u_int32_t reg, int value)
 }
 
 static int pim_dom_fpga_mdio_done(int fru, int phy) {
-    int retry = 10;
+    int retry = 0;
     int value = 0;
     int mdio_status_addr = MDIO_BASE(phy) + DOM_FPGA_MDIO_STATUS;
     do {


### PR DESCRIPTION
The origin value of retry is 10, but we found that the condition for the while loop makes the loop always goes only once.
Thus, we modify the value to 0 and make the loop more reasonable.
