### PR TITLE
Drop meta-facebook/meta-yamp/recipes-core/facebook/yamp-image.bbappend

### DIFF
--- a/meta-facebook/meta-yamp/recipes-core/facebook/yamp-image.bbappend
+++ b/meta-facebook/meta-yamp/recipes-core/facebook/yamp-image.bbappend
@@ -1,3 +1,0 @@
-# Copyright 2018-present Facebook. All Rights Reserved.
-# This file is a placeholder to add more items for packaging, 
-# in addition to the ones in image.bb


### PR DESCRIPTION
Summary:
meta-facebook/meta-yamp/recipes-core/facebook/yamp-image.bbappend doesn't need to be maintained externally, hence dropping it.

Test Plan:
CIT passes.

Reviewers:amithash, williamspatrick

# Description

Please include a summary of the change and which issue is fixed.

# Motivation

Please include an explanation of why you these changes are necessary

# Test Plan

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
