### PR TITLE
actions: update checkout action to v3

### DIFF
--- a/.github/workflows/flashy.yml
+++ b/.github/workflows/flashy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run unit tests
         run: tools/flashy/scripts/run_unit_tests.sh
 
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build flashy
         run: tools/flashy/build.sh
       - name: Upload artifact
@@ -42,7 +42,7 @@ jobs:
       - flashy-build
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download flashy build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -31,7 +31,7 @@ jobs:
             echo "contains_c_source=false" >> $GITHUB_ENV
           fi
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Repo
         if: env.contains_c_source == 'true'
         
@@ -91,7 +91,7 @@ jobs:
         # Unfortunately some shell files don't have an extension.
         # This means we need to checkout the entire repo just to see if we need
         # to lint anything...
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Repo
 
       - name: Get PR File List 
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Repo
        
       - uses: reviewdog/action-setup@v1


### PR DESCRIPTION
Summary: Updates the checkout action to v3. Github was showing a warning that this will be deprecated soon. One of the other workflows already uses this so this gets everything on the same page

Test Plan: CI

Differential Revision: D46196076

Reviewed By: smithscott

