### PR TITLE
ci: fix flashy tests

### DIFF
--- a/tools/flashy/lib/utils/system_test.go
+++ b/tools/flashy/lib/utils/system_test.go
@@ -178,10 +178,10 @@ func TestRunCommand(t *testing.T) {
 			wantExitCode: 127,
 			wantErr:      errors.Errorf("exit status 127"),
 			wantStdout:   "",
-			wantStderr:   "bash: ech0: command not found\n",
+			wantStderr:   "bash: line 1: ech0: command not found\n",
 			logContainsSeq: []string{
 				"Running command 'bash -c ech0 openbmc' with 30s timeout",
-				"stderr: bash: ech0: command not found",
+				"stderr: bash: line 1: ech0: command not found",
 				"Command 'bash -c ech0 openbmc' exited with code 127 after",
 			},
 		},


### PR DESCRIPTION
Summary: This test was failing in CI because the expected output was not what was actually being logged. It was just a simple miss and not indicative of any other problem so this just adjusts the expected result.

Test Plan: CI

Differential Revision: D46232899

Reviewed By: smithscott

