### PR TITLE
montblanc: uboot: mdio configure phy chip

### DIFF
--- a/meta-facebook/meta-montblanc/recipes-bsp/u-boot/files/facebook-fblite_defconfig.append
+++ b/meta-facebook/meta-montblanc/recipes-bsp/u-boot/files/facebook-fblite_defconfig.append
@@ -10,5 +10,5 @@ CONFIG_PHY_FIXED=y
 
 # Platform specific override
 CONFIG_DEFAULT_DEVICE_TREE="aspeed-bmc-facebook-fblite"
-CONFIG_SYS_CONFIG_NAME="facebook_fblite"
+CONFIG_SYS_CONFIG_NAME="facebook_fbmontblanc"
 CONFIG_SYS_PROMPT="montblanc-boot=> "

--- a/meta-facebook/meta-montblanc/recipes-bsp/u-boot/patches/1001-montblanc-add-marvel-phy-configuration.patch
+++ b/meta-facebook/meta-montblanc/recipes-bsp/u-boot/patches/1001-montblanc-add-marvel-phy-configuration.patch
@@ -1,0 +1,223 @@
+From 0bbc3bf641c323d72aff0d2e0c053ba9245ee3b1 Mon Sep 17 00:00:00 2001
+From: Bin Huang <binhuang@meta.com>
+Date: Fri, 9 Jun 2023 13:39:18 +0700
+Subject: [PATCH] montblanc: uboot: mdio configure phy chip
+
+Signed-off-by: Bin Huang <binhuang@meta.com>
+---
+ board/fb-obmc/ast/Makefile                |   1 +
+ board/fb-obmc/ast/ast-g6.c                |   8 +
+ board/fb-obmc/ast/montblanc.c             | 145 ++++++++++++++++++
+ include/configs/facebook_fbmontblanc.h    |  13 ++
+ 4 files changed, 167 insertions(+)
+ create mode 100644 board/fb-obmc/ast/montblanc.c
+ create mode 100644 include/configs/facebook_fbmontblanc.h
+
+diff --git a/board/fb-obmc/ast/Makefile b/board/fb-obmc/ast/Makefile
+index 52df3e5d87b..73e6f8d9656 100644
+--- a/board/fb-obmc/ast/Makefile
++++ b/board/fb-obmc/ast/Makefile
+@@ -1,3 +1,4 @@
++obj-$(CONFIG_FBMONTBLANC) += montblanc.o 
+ obj-$(CONFIG_ELBERTVBOOT) += elbert.o 
+ obj-$(CONFIG_SPL) += vboot-abb.o
+ ifeq ($(CONFIG_SPL_BUILD), y)
+diff --git a/board/fb-obmc/ast/ast-g6.c b/board/fb-obmc/ast/ast-g6.c
+index 716fa06456b..6b6c76daf9d 100644
+--- a/board/fb-obmc/ast/ast-g6.c
++++ b/board/fb-obmc/ast/ast-g6.c
+@@ -167,6 +167,10 @@ static void system_status_led_init(void)
+ extern void configureBcm53134(void);
+ #endif
+ 
++#ifdef CONFIG_FBMONTBLANC
++extern void configure88E1512(void);
++#endif
++
+ #ifdef CONFIG_FBY35
+ static void pwm_init(void) {
+ #define PWM_COUNT 4
+@@ -301,6 +305,10 @@ int board_init(void)
+ 	configureBcm53134();
+ #endif /* ELBERT specific */
+ 
++#ifdef CONFIG_FBMONTBLANC
++	configure88E1512();
++#endif /* CONFIG_FBMONTBLANC */
++
+ #if defined(CONFIG_FBGT) || defined(CONFIG_FBGTI) || defined(CONFIG_FBGTARTEMIS)
+ 	clrbits_le32(SCU_HW_STRAP3_REG, ENABLE_GPIO_PASSTHROUGH);
+ 	el_port80_init(GPIO_MNOP_DIR_REG, GPIO_GROUP('N', 0xFF),
+diff --git a/board/fb-obmc/ast/montblanc.c b/board/fb-obmc/ast/montblanc.c
+new file mode 100644
+index 00000000000..4b6a87ded0c
+--- /dev/null
++++ b/board/fb-obmc/ast/montblanc.c
+@@ -0,0 +1,145 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (c) Meta Platforms, Inc. and affiliates.
++ */
++
++#include <common.h>
++#include <asm/io.h>
++
++/* SCU Base Address */
++#define AST_SCU_VA_BASE             0x1E6E2000
++/* PMI Base Address */
++#define AST_PMI_VA_BASE             0x1E650000
++
++#define SCU_RESET_SET2_REG          (AST_SCU_VA_BASE + 0x50)
++#define SCU_RESET_CLEAR2_REG        (AST_SCU_VA_BASE + 0x54)
++#define SCU_PIN_CONTROL4_REG        (AST_SCU_VA_BASE + 0x410)
++
++/* SCU[50] */
++#define SCU_RESET_MII_CONTROLLER    (1 << 3)    /* Reset the MII controller */
++
++/* SCU[410] */
++#define SCU_ENABLE_MDC2_PIN          (1 << 12)   /* Enable MDC */
++#define SCU_ENABLE_MDIO2_PIN         (1 << 13)   /* Enable MDIO */
++
++/* MDIO */
++#define PMI_MDC_MDIO_CONTROL_REG(mdio)    (AST_PMI_VA_BASE + (0x8*(mdio-1)) + 0x0)
++#define PMI_MDC_MDIO_READ_DATA_REG(mdio)  (AST_PMI_VA_BASE + (0x8*(mdio-1)) + 0x4)
++
++#define MDIO_UDELAY               10
++
++/* MDIO MARVEL PHY */
++#define MDIO_PHY_PAGE_REG 22
++#define MDIO_PHY_ADDR 0x00
++
++void mdio_init(void)
++{
++    unsigned long val;
++    *(volatile unsigned long *)(SCU_RESET_CLEAR2_REG) = SCU_RESET_MII_CONTROLLER;
++
++    val = *(volatile unsigned long *)(SCU_PIN_CONTROL4_REG);
++    val |= (SCU_ENABLE_MDC2_PIN | SCU_ENABLE_MDIO2_PIN);
++    *(volatile unsigned long *)(SCU_PIN_CONTROL4_REG) = val;
++}
++
++void mdio_restore(void)
++{
++    unsigned long val;
++    *(volatile unsigned long *)(SCU_RESET_SET2_REG) = SCU_RESET_MII_CONTROLLER;
++
++    val = *(volatile unsigned long *)(SCU_PIN_CONTROL4_REG);
++    val &= ~(SCU_ENABLE_MDC2_PIN | SCU_ENABLE_MDIO2_PIN);
++    *(volatile unsigned long *)(SCU_PIN_CONTROL4_REG) = val;
++}
++
++int mdio_wait_op_complete(unsigned int reg_addr, unsigned long mask,
++                          unsigned long wait_val)
++{
++    int maxTries = 30;
++    int i;
++    unsigned long val;
++    for (i = 0; i < maxTries; ++i) {
++        val = *(volatile unsigned long *)reg_addr;
++        if ((val & mask) == wait_val) {
++            return 0;
++        }
++        udelay(MDIO_UDELAY);
++    }
++    return -1;
++}
++
++/* mdio_read returns register values between 0x0 and 0xffff
++   in the case of success and -1 in the case of failure. */
++int mdio_read(unsigned long mdio, unsigned long phy, unsigned long addr)
++{
++    unsigned long reg_val;
++    unsigned long fire_busy = (unsigned long) 1 << 31;
++    unsigned long ctrl_idle = (unsigned long) 1 << 16;
++
++    reg_val = fire_busy
++            | (1 << 28)    /* clause_22 */
++            | (1 << 27)    /* read request */
++            | (phy << 21) /* pseudo-phy port address */
++            | (addr << 16);
++    *(volatile unsigned long *)(PMI_MDC_MDIO_CONTROL_REG(mdio)) = reg_val;
++    if (mdio_wait_op_complete(PMI_MDC_MDIO_READ_DATA_REG(mdio), ctrl_idle,
++                              ctrl_idle)) {
++        return -1;
++    }
++    reg_val = *(volatile unsigned long *)(PMI_MDC_MDIO_READ_DATA_REG(mdio));
++    return (int)(reg_val & 0xffff);
++}
++
++int mdio_write(unsigned long mdio, unsigned long phy, unsigned long addr,
++    unsigned long val)
++{
++    unsigned long reg_val;
++    unsigned long fire_busy = (unsigned long) 1 << 31;
++
++    reg_val = fire_busy
++            | (1 << 28)    /* clause_22 */
++            | (1 << 26)    /* write request */
++            | (phy << 21) /* pseudo-phy port address */
++            | (addr << 16)
++            | val;
++    *(volatile unsigned long *)(PMI_MDC_MDIO_CONTROL_REG(mdio)) = reg_val;
++    return mdio_wait_op_complete(PMI_MDC_MDIO_CONTROL_REG(mdio), fire_busy, 0);
++}
++
++int program_phy_register(unsigned long page, unsigned long addr, 
++    unsigned long mask, unsigned long val)
++{
++    unsigned long tmp;
++    const unsigned long mdio = 2;
++    const unsigned long phy = MDIO_PHY_ADDR;
++
++    tmp = page;
++    if (mdio_write(mdio, phy, MDIO_PHY_PAGE_REG, tmp)) {
++        return -1;
++    }
++
++    tmp = (unsigned long)mdio_read(mdio, phy, addr);
++    tmp = (tmp & mask) | val;
++
++    if (mdio_write(mdio, phy, addr, tmp)) {
++        return -1;
++    }
++
++    if (mdio_write(mdio, phy, MDIO_PHY_PAGE_REG, 0)) {
++        return -1;
++    }
++
++    return 0;
++}
++
++int configure88E1512(void)
++{
++    mdio_init();
++
++    program_phy_register(0x2, 0x15, 0xffcf, 0x0000);    // disable RGMII Delay
++    program_phy_register(0x12, 0x14, 0x7ff8, 0x8002);   // mode RGMII to 1000Base-X
++
++    mdio_restore();
++
++    return 0;
++}
+diff --git a/include/configs/facebook_fbmontblanc.h b/include/configs/facebook_fbmontblanc.h
+new file mode 100644
+index 00000000000..c2b2393f362
+--- /dev/null
++++ b/include/configs/facebook_fbmontblanc.h
+@@ -0,0 +1,13 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (c) Meta Platforms, Inc. and affiliates.
++ */
++
++#ifndef __CONFIG_FBMONTBLANC_H
++#define __CONFIG_FBMONTBLANC_H
++
++#include <configs/facebook_fblite.h>
++
++#define CONFIG_FBMONTBLANC
++
++#endif	/* __CONFIG_FBMONTBLANC_H */
+-- 
+2.25.1
+

--- a/meta-facebook/meta-montblanc/recipes-bsp/u-boot/u-boot-fw-utils_2019.04.bbappend
+++ b/meta-facebook/meta-montblanc/recipes-bsp/u-boot/u-boot-fw-utils_2019.04.bbappend
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This program file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program in a file named COPYING; if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/patches:"
+
+#
+# Include montblanc-specific patches
+#
+SRC_URI += "file://1001-montblanc-add-marvel-phy-configuration.patch \
+           "

--- a/meta-facebook/meta-montblanc/recipes-bsp/u-boot/u-boot_2019.04.bbappend
+++ b/meta-facebook/meta-montblanc/recipes-bsp/u-boot/u-boot_2019.04.bbappend
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This program file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program in a file named COPYING; if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/patches:"
+
+#
+# Include montblanc-specific patches
+#
+SRC_URI += "file://1001-montblanc-add-marvel-phy-configuration.patch \
+           "


### PR DESCRIPTION
Summary:
# Description
- initial configure Marvell PHY chip mode at u-boot start

# Motivation
- enable ethernet be used in u-boot, without need configure in OpenBMC once

X-link: https://github.com/facebookexternal/openbmc.celestica/pull/1572

Test Plan:
- use "wedge_power.sh reset -s" command to cold-reset, start the unit from power-off
- stop boot process in u-boot
- use "dhcp" command to validate u-boot able to get IP and able to get file
```
root@bmc-oob:~# wedge_power.sh reset -s
Power reset the whole system ...

U-Boot 2019.04 montblanc-10a0fe30934-CLS_main (Jun 08 2023 - 07:27:48 +0000)

SOC: AST2620-A3
RST: Power On
eSPI Mode: SIO:Enable : SuperIO-2e
Eth: MAC0: RMII/NCSI, MAC1: RMII/NCSI, MAC2: RMII/NCSI, MAC3: RMII/NCSI
Model: Aspeed BMC
DRAM:  1.8 GiB (capacity:2048 MiB, VGA:0 MiB, ECC:on, ECC size:1820 MiB)
MMC:   emmc_slot0@100: 0
Loading Environment from SPI Flash... SF: Detected mx66l1g45g with page size 256 Bytes, erase size 64 *** Warning - bad CRC, using default environment

Saving Environment to SPI Flash... SF: Detected mx66l1g45g with page size 256 Bytes, erase size 64 KiBErasing SPI flash...Writing to SPI flash...done
OK
In:    serial
Out:   serial
Err:   serial
Model: Aspeed BMC
Net:   No MDIO found.

Warning: ftgmac@1e690000 (eth0) using random MAC address - fa:6f:d6:79:7d:b8
eth0: ftgmac@1e690000
autoboot in 3 seconds (stop with 'Delete' key)...
montblanc-boot=> dhcp
ftgmac@1e690000: link up, 1000 Mbps full-duplex mac:fa:6f:d6:79:7d:b8
BOOTP broadcast 1
BOOTP broadcast 2
BOOTP broadcast 3
DHCP client bound to address 192.168.10.58 (1030 ms)
*** Warning: no boot file name; using 'C0A80A3A.img'
Using ftgmac@1e690000 device
TFTP from server 192.168.10.50; our IP address is 192.168.10.58
Filename 'C0A80A3A.img'.
Load address: 0x83000000
Loading: *
TFTP error: 'File not found' (1)
Not retrying...
montblanc-boot=> bootp 0x83000000 192.168.10.50:flash-montblanc
ftgmac@1e690000: link up, 1000 Mbps full-duplex mac:fa:6f:d6:79:7d:b8
BOOTP broadcast 1
DHCP client bound to address 192.168.10.58 (22 ms)
Using ftgmac@1e690000 device
TFTP from server 192.168.10.50; our IP address is 192.168.10.58
Filename 'flash-montblanc'.
Load address: 0x83000000
Loading: #################################################################
         #################################################################
...
         #################################################################
         ###############################################
8.1 MiB/s
done
Bytes transferred = 29315666 (1bf5252 hex)
montblanc-boot=>
```

Differential Revision: D46591989

Reviewed By: ssinprem

