### PR TITLE
cit: fuji: resolved the test case "test_endpoint_api_sys_sensors" failure.

### DIFF
--- a/tests2/tests/fuji/helper/libpal.py
+++ b/tests2/tests/fuji/helper/libpal.py
@@ -105,3 +105,12 @@ def pal_get_fru_id(fru_name: str) -> int:
         raise ValueError("Invalid FRU name: " + repr(fru_name))
 
     return c_fru_id.value
+
+
+def pal_get_pim_inserted_list():
+    pim_list = []
+    for pim_number in range(8):
+        pim = "pim{}".format(pim_number + 1)
+        if pal_is_fru_prsnt(pal_get_fru_id(pim)):
+            pim_list.append(pim_number)
+    return pim_list

--- a/tests2/tests/fuji/test_rest_endpoint.py
+++ b/tests2/tests/fuji/test_rest_endpoint.py
@@ -21,7 +21,11 @@ import os
 import unittest
 
 from common.base_rest_endpoint_test import FbossRestEndpointTest
-from tests.fuji.helper.libpal import pal_get_fru_id, pal_is_fru_prsnt
+from tests.fuji.helper.libpal import (
+    pal_get_fru_id,
+    pal_is_fru_prsnt,
+    pal_get_pim_inserted_list,
+)
 from tests.fuji.test_data.sensors.sensor import (
     PIM1_SENSORS_16O,
     PIM1_SENSORS_16Q,
@@ -155,7 +159,7 @@ class RestEndpointTest(FbossRestEndpointTest, unittest.TestCase):
             3: PSU3_SENSORS,
             4: PSU4_SENSORS,
         }
-        pim_list = [0, 1, 2, 3, 4, 5, 6, 7]
+        pim_list = pal_get_pim_inserted_list()
         pim_16q_sensor_list = {
             0: PIM1_SENSORS_16Q,
             1: PIM2_SENSORS_16Q,


### PR DESCRIPTION
Summary:
# Description

**Issue:**
CIT test case "test_endpoint_api_sys_sensors" failed on FUJI DC units only.

**Root cause Analysis:**
This test case commonly checks for all PIM sensors irrespective of device configuration. Since DC device(4 or 5 PIM) have differed from AC unit(8 PIM) in PIM configuration, the test case is failed.

**Fix:**
Test case has been altered to execute only for inserted PIMs.

# Motivation

These changes will get the list of inserted PIMs and execute the rest endpoint test cases for only inserted PIMs.

X-link: https://github.com/facebookexternal/openbmc.celestica/pull/1578

Test Plan:
**Steps to reproduce:**
Execute the test case in DC Fuji devices to get the failure.
- python cit_runner.py --run-test  tests.fuji.test_rest_endpoint.RestEndpointTest.test_endpoint_api_sys_sensors

**Unit test logs:**
In DC unit:

```
root@bmc-oob:/usr/local/bin/tests2# python cit_runner.py --run-test  tests.fuji.test_rest_endpoint.RestEndpointTest.test_endpoint_api_sys_sensors
test_endpoint_api_sys_sensors (tests.fuji.test_rest_endpoint.RestEndpointTest.test_endpoint_api_sys_sensors) ... ok

----------------------------------------------------------------------
Ran 1 test in 3.882s

OK
```
In AC unit:

```
root@bmc-oob:/usr/local/bin/tests2# python cit_runner.py --run-test  tests.fuji.test_rest_endpoint.RestEndpointTest.test_endpoint_api_sys_sensors
test_endpoint_api_sys_sensors (tests.fuji.test_rest_endpoint.RestEndpointTest.test_endpoint_api_sys_sensors) ... ok

----------------------------------------------------------------------
Ran 1 test in 4.089s

OK
```
**CIT log:**
[CIT_FUJI_DC_unit_log.txt](https://github.com/facebookexternal/openbmc.celestica/files/11768797/CIT_FUJI_DC_unit_log.txt)

Differential Revision: D46795517

Reviewed By: vijay.g

