### PR TITLE
yv4: cxl-fw-update: fix incorrect cast in recvfrom function call

### DIFF
--- a/meta-facebook/meta-yosemite4/recipes-facebook/cxl-fw-update/files/cci-mctp-update.cpp
+++ b/meta-facebook/meta-yosemite4/recipes-facebook/cxl-fw-update/files/cci-mctp-update.cpp
@@ -41,7 +41,7 @@ int get_fw_ver_cci_over_mctp(uint8_t eid)
 
     std::cerr << "Get Firmware Info for EID: " << +eid << std::endl;
 
-    auto addrlen = sizeof(struct sockaddr_mctp);
+    socklen_t addrlen = sizeof(struct sockaddr_mctp);
     addr.smctp_base.smctp_family = AF_MCTP;
     addr.smctp_base.smctp_network = DEFAULT_NET;
     addr.smctp_base.smctp_addr.s_addr = eid;


### PR DESCRIPTION
# Description

Fixe the issue by changing the declaration to 'socklen_t' for variable 'addrlen'

# Motivation

Fix build break ../cci-mctp-update.cpp:77:20: error: cannot convert 'long unsigned int*' to 'socklen_t*' {aka 'unsigned int*'}

# Test Plan

Build pass on Nuvoton NPCM8XX 64-bit BMC
