### PR TITLE
cpld-fw-handler: support to update EBR_INIT data

### DIFF
--- a/common/recipes-utils/cpld-fw-handler/cpld-fw-handler_0.1.bb
+++ b/common/recipes-utils/cpld-fw-handler/cpld-fw-handler_0.1.bb
@@ -16,6 +16,8 @@ LOCAL_URI = " \
     file://cpld-lattice.cpp \
     file://cpld-lattice.hpp \
     file://meson.build \
+    file://meson_options.txt \
     "
 
+EXTRA_OEMESON:append:npcm8xx = " -Dupdate-ebr-init=enabled"
 DEPENDS += "cli11"

--- a/common/recipes-utils/cpld-fw-handler/files/cpld-lattice.cpp
+++ b/common/recipes-utils/cpld-fw-handler/files/cpld-lattice.cpp
@@ -27,6 +27,9 @@ int CpldLatticeManager::jedFileParser()
     bool ufmPrepare = false;
     bool versionStart = false;
     bool checksumStart = false;
+#ifdef ENABLE_UPDATE_EBR_INIT
+    bool ebrInitDataStart = false;
+#endif
     int numberSize = 0;
 
     std::string line;
@@ -58,6 +61,12 @@ int CpldLatticeManager::jedFileParser()
         {
             cfStart = true;
         }
+#ifdef ENABLE_UPDATE_EBR_INIT
+        else if (line.rfind(TAG_EBR_INIT_DATA, 0) == 0)
+        {
+            ebrInitDataStart = true;
+        }
+#endif
         else if (ufmPrepare == true)
         {
             ufmPrepare = false;
@@ -121,7 +130,52 @@ int CpldLatticeManager::jedFileParser()
                     std::cerr << "CF Size = " << fwInfo.cfgData.size()
                               << std::endl;
                     cfStart = false;
-                    ufmPrepare = true;
+#ifdef ENABLE_UPDATE_EBR_INIT
+                    if (ebrInitDataStart == false)
+                    {
+                        ufmPrepare = true;
+                    }
+                }
+            }
+        }
+        else if (ebrInitDataStart == true)
+        {
+            // NOTE EBR_INIT DATA
+            if ((line.rfind(TAG_EBR_INIT_DATA, 0)) && (line.size() != 1))
+            {
+                if ((line.rfind("L", 0)) && (line.size() != 1))
+                {
+                    if ((line.rfind("0", 0) == 0) || (line.rfind("1", 0) == 0))
+                    {
+                        while (line.size())
+                        {
+                            auto binary_str = line.substr(0, 8);
+                            try
+                            {
+                                fwInfo.cfgData.push_back(
+                                    std::stoi(binary_str, 0, 2));
+                                line.erase(0, 8);
+                            }
+                            catch (const std::invalid_argument& error)
+                            {
+                                break;
+                            }
+                            catch (...)
+                            {
+                                std::cerr << "Error while parsing CF section"
+                                        << std::endl;
+                                return -1;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        std::cerr << "CF Size with ERB_INIT Data = " << fwInfo.cfgData.size()
+                                << std::endl;
+                        ebrInitDataStart = false;
+                        ufmPrepare = true;
+                    }
+#endif
                 }
             }
         }

--- a/common/recipes-utils/cpld-fw-handler/files/cpld-lattice.hpp
+++ b/common/recipes-utils/cpld-fw-handler/files/cpld-lattice.hpp
@@ -16,6 +16,7 @@ static constexpr auto TAG_UFM = "NOTE TAG DATA";
 static constexpr auto TAG_ROW = "NOTE FEATURE";
 static constexpr auto TAG_CHECKSUM = "C";
 static constexpr auto TAG_USERCODE = "NOTE User Electronic";
+static constexpr auto TAG_EBR_INIT_DATA = "NOTE EBR_INIT DATA";
 
 constexpr uint8_t isOK = 0;
 constexpr uint8_t isReady = 0;

--- a/common/recipes-utils/cpld-fw-handler/files/meson.build
+++ b/common/recipes-utils/cpld-fw-handler/files/meson.build
@@ -9,6 +9,11 @@ project('cpld-fw-handler', 'cpp',
     license: 'Apache-2.0',
     version: '1.0')
 
+if get_option('update-ebr-init').enabled()
+    add_project_arguments('-DENABLE_UPDATE_EBR_INIT', language: 'cpp')
+    summary('update-ebr-init', '-DENABLE_UPDATE_EBR_INIT', section: 'Enabled Features')
+endif
+
 executable(
     'cpld-fw-handler',
     'cpld-fw-main.cpp',

--- a/common/recipes-utils/cpld-fw-handler/files/meson_options.txt
+++ b/common/recipes-utils/cpld-fw-handler/files/meson_options.txt
@@ -1,0 +1,7 @@
+option(
+    'update-ebr-init',
+    type: 'feature',
+    value: 'disabled',
+    description: '''Support to update EBR_INIT data so BMC could update
+                    Nuvoton MGM CPLD firmware.'''
+)


### PR DESCRIPTION
Summary:
Support to update EBR_INIT data so BMC could update Nuvoton MGM CPLD firmware.

# Test Plan
Build and test pass on YV4 system.
