### PR TITLE
yosemite4n: initial layer config

### DIFF
--- a/meta-facebook/meta-yosemite4/meta-yosemite4n/conf/layer.conf
+++ b/meta-facebook/meta-yosemite4/meta-yosemite4n/conf/layer.conf
@@ -1,0 +1,14 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	        ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+# Ignore bbappend related to ASPEED in meta-yosemite4
+BBMASK += ".*aspeed.*\.bbappend"
+
+BBFILE_COLLECTIONS += "fb-yosemite4n-layer"
+BBFILE_PATTERN_fb-yosemite4n-layer := "^${LAYERDIR}/"
+LAYERVERSION_fb-yosemite4n-layer = "1"
+LAYERSERIES_COMPAT_fb-yosemite4n-layer = "scarthgap nanbield kirkstone"

--- a/meta-facebook/meta-yosemite4/meta-yosemite4n/conf/templates/default/bblayers.conf.sample
+++ b/meta-facebook/meta-yosemite4/meta-yosemite4n/conf/templates/default/bblayers.conf.sample
@@ -1,0 +1,25 @@
+# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+LCONF_VERSION = "8"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ##OEROOT##/meta \
+  ##OEROOT##/meta-openembedded/meta-oe \
+  ##OEROOT##/meta-openembedded/meta-networking \
+  ##OEROOT##/meta-openembedded/meta-python \
+  ##OEROOT##/meta-security/meta-tpm \
+  ##OEROOT##/meta-phosphor \
+  ##OEROOT##/meta-arm/meta-arm \
+  ##OEROOT##/meta-arm/meta-arm-toolchain \
+  ##OEROOT##/meta-nuvoton \
+  ##OEROOT##/meta-facebook \
+  ##OEROOT##/meta-facebook/meta-yosemite4 \
+  ##OEROOT##/meta-facebook/meta-yosemite4/meta-yosemite4n \
+  ##OEROOT##/../.. \
+  ##OEROOT##/../../meta-facebook \
+  ##OEROOT##/../../meta-facebook/meta-yosemite4 \
+  ##OEROOT##/../../meta-facebook/meta-yosemite4/meta-yosemite4n  \
+  "

--- a/meta-facebook/meta-yosemite4/meta-yosemite4n/conf/templates/default/conf-notes.txt
+++ b/meta-facebook/meta-yosemite4/meta-yosemite4n/conf/templates/default/conf-notes.txt
@@ -1,0 +1,2 @@
+Common targets are:
+    yosemite4n-image

--- a/meta-facebook/meta-yosemite4/meta-yosemite4n/conf/templates/default/local.conf.sample
+++ b/meta-facebook/meta-yosemite4/meta-yosemite4n/conf/templates/default/local.conf.sample
@@ -1,0 +1,5 @@
+#
+# Local configuration file for building the OpenBMC image.
+#
+MACHINE ??= "yosemite4n"
+DISTRO ?= "openbmc-fb-lf"

--- a/meta-facebook/meta-yosemite4/meta-yosemite4n/recipes-core/images/yosemite4n-image.bb
+++ b/meta-facebook/meta-yosemite4/meta-yosemite4n/recipes-core/images/yosemite4n-image.bb
@@ -1,0 +1,3 @@
+require recipes-core/images/yosemite4-image.bb
+
+IMAGE_INSTALL:remove = " packagegroup-openbmc-tests2"

--- a/openbmc-init-build-env
+++ b/openbmc-init-build-env
@@ -56,6 +56,7 @@ PLAT_DISTRO_OVERRIDES=(
   meta-ventura:lf-master
   meta-waimeacanyon:lf-master
   meta-yosemite4:lf-master
+  meta-yosemite4n:lf-master
 # dunfell platforms (pending upgrade)
   meta-cmm:lf-dunfell
   meta-fbsp:lf-dunfell

--- a/tools/platforms/platform_build_names
+++ b/tools/platforms/platform_build_names
@@ -42,5 +42,6 @@
   "wedge400",
   "yamp",
   "yosemite",
-  "yosemite4"
+  "yosemite4",
+  "yosemite4n"
 ]


### PR DESCRIPTION
# Description

Initial layer config for meta-yosemite4n.

# Motivation

yosemite4n is a new system based on yosemite4 and Nuvoton management board. Create the layer config enough to build it.

# Test Plan

bitbake yosemite4n-image - Build Pass