### PR TITLE
yosemite4n: u-boot: Add patch to set memory test result in environment

### DIFF
--- a/meta-facebook/meta-yosemite4/meta-yosemite4n/recipes-bsp/u-boot/u-boot-nuvoton/0100-cmd-mem-set-test-result-of-mtest-to-enviroment-varia.patch
+++ b/meta-facebook/meta-yosemite4/meta-yosemite4n/recipes-bsp/u-boot/u-boot-nuvoton/0100-cmd-mem-set-test-result-of-mtest-to-enviroment-varia.patch
@@ -1,0 +1,46 @@
+From fd6c1631c9075161df703e7928063f4acf498113 Mon Sep 17 00:00:00 2001
+From: RickyWu-wiwynn <ricky_cx_wu@wiwynn.com>
+Date: Mon, 8 Apr 2024 18:07:34 +0800
+Subject: [PATCH] cmd: mem: set test result of mtest to enviroment variable
+
+---
+ cmd/mem.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/cmd/mem.c b/cmd/mem.c
+index 5f4e865462..4dee413fea 100644
+--- a/cmd/mem.c
++++ b/cmd/mem.c
+@@ -1204,6 +1204,15 @@ static ulong mem_test_quick(vu_long *buf, ulong start_addr, ulong end_addr,
+ static int do_mem_mtest(struct cmd_tbl *cmdtp, int flag, int argc,
+ 			char *const argv[])
+ {
++	char *is_done;
++	is_done = env_get("memtest_result");
++	if (is_done != NULL) {
++		env_set("memtest_result", "");
++		env_set("preboot", "");
++		env_save();
++		return 0;
++	}
++
+ 	ulong start, end;
+ 	vu_long scratch_space;
+ 	vu_long *buf, *dummy = &scratch_space;
+@@ -1273,6 +1282,13 @@ static int do_mem_mtest(struct cmd_tbl *cmdtp, int flag, int argc,
+ 
+ 	printf("\nTested %d iteration(s) with %lu errors.\n", iteration, count);
+ 
++	if (errs == 0) {
++		env_set("memtest_result", "pass");
++	} else {
++		env_set("memtest_result", "fail");
++	}
++	env_save();
++
+ 	return errs != 0;
+ }
+ #endif	/* CONFIG_CMD_MEMTEST */
+-- 
+2.25.1
+

--- a/meta-facebook/meta-yosemite4/meta-yosemite4n/recipes-bsp/u-boot/u-boot-nuvoton_%.bbappend
+++ b/meta-facebook/meta-yosemite4/meta-yosemite4n/recipes-bsp/u-boot/u-boot-nuvoton_%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+require ../../../../../common/recipes-bsp/u-boot/u-boot-version-override.inc
+
+SRC_URI:append = " file://0100-cmd-mem-set-test-result-of-mtest-to-enviroment-varia.patch"
+


### PR DESCRIPTION
# Description

Add u-boot patch to set memory test result in environment.

# Motivation

Add patch to set memory test result in environment after doing mtest in u-boot so that user can check the result in user space. This patch is needed by Wiwynn factory test.

# Test Plan

Set mtest command and reboot to check the memory test result.

root@bmc:~# fw_setenv preboot 'mtest 0x80000000 0x9A500000 0 1'
root@bmc:~# reboot
root@bmc:~# fw_printenv memtest_result
memtest_result=pass