### PR TITLE
yosemite4n: cpld-fw-handler: Support to update EBR_INIT data

### DIFF
--- a/meta-facebook/meta-yosemite4/meta-yosemite4n/recipes-facebook/cpld-fw-handler/cpld-fw-handler_%.bbappend
+++ b/meta-facebook/meta-yosemite4/meta-yosemite4n/recipes-facebook/cpld-fw-handler/cpld-fw-handler_%.bbappend
@@ -1,0 +1,2 @@
+EXTRA_OEMESON:append = " -Dupdate-ebr-init=enabled"
+


### PR DESCRIPTION
# Description

Support to update EBR_INIT data.

# Motivation

Enable update-ebr-init option to support updating EBR_INIT data so that BMC could update Nuvoton MGM CPLD firmware.

# Test Plan

Build and test pass on YV4 system.
