### PR TITLE
Update flashy.yml version of download-artifact

### DIFF
--- a/.github/workflows/flashy.yml
+++ b/.github/workflows/flashy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Download flashy build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v5
         with:
           name: flashy
           path: tools/flashy/build


### PR DESCRIPTION
download-artifact v2 is deprecated and is failing to build. Updating it to the most recent version

