### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/flashy.yml
+++ b/.github/workflows/flashy.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run unit tests
         run: tools/flashy/scripts/run_unit_tests.sh
 
@@ -22,14 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build flashy
         run: tools/flashy/build.sh
       - name: Upload artifact
         if: github.ref == 'refs/heads/helium'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: flashy
           path: tools/flashy/build/
@@ -42,9 +42,9 @@ jobs:
       - flashy-build
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Download flashy build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: flashy
           path: tools/flashy/build

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -8,7 +8,7 @@ jobs:
         # Unfortunately some shell files don't have an extension.
         # This means we need to checkout the entire repo just to see if we need
         # to lint anything...
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         name: Checkout Repo
 
       - name: Get PR File List
@@ -74,7 +74,7 @@ jobs:
           echo "Errors Found:"
           cat /tmp/shellcheck.log
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v6
         name: Upload shellcheck error log
         if: env.contains_shell_files == 'true'
         with:
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         name: Checkout Repo
 
       - uses: reviewdog/action-setup@v1
@@ -103,7 +103,7 @@ jobs:
           reviewdog_version: latest
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/artifacts
 

--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout OpenBMC
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Build QEMU
         uses: ./.github/actions/build_qemu
       - name: Save qemu-system-aarch64 build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: qemu-system-aarch64
           path: ./build/workspace/sources/qemu-system-native/build/qemu-system-aarch64
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Download QEMU binary
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v7
         with:
           name: qemu-system-aarch64
       - name: Add qemu-system-aarch64 release artifact


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/download-artifact` | [``](https://github.com/actions/download-artifact/releases/tag/) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) |  |
| `actions/setup-go` | [``](https://github.com/actions/setup-go/releases/tag/) | [`v6`](https://github.com/actions/setup-go/releases/tag/v6) | [Release](https://github.com/actions/setup-go/releases/tag/v6) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
