### PR TITLE
fw_upgrade: fix 'occured' -> 'occurred' in upgrade log/error messages

### DIFF
--- a/tests2/common/base_fw_upgrade_test.py
+++ b/tests2/common/base_fw_upgrade_test.py
@@ -529,7 +529,7 @@ class BaseFwUpgradeTest(object):
                     return False
             return True
         except Exception as e:
-            Logger.info("Exception {} occured when running command".format(e))
+            Logger.info("Exception {} occurred when running command".format(e))
             return False
 
     def checking_components_version(self, components=None, logging=False):

--- a/tools/fw_upgrade/entity_upgrader.py
+++ b/tools/fw_upgrade/entity_upgrader.py
@@ -248,7 +248,7 @@ class FwEntityUpgrader(object):
             subprocess.check_call(cmd_to_execute, shell=True, stderr=subprocess.STDOUT)
             return 0
         except subprocess.CalledProcessError as e:
-            logging.info("Exception {} occured when running command".format(e))
+            logging.info("Exception {} occurred when running command".format(e))
             return e.returncode
 
     # Step 4
@@ -275,7 +275,7 @@ class FwEntityUpgrader(object):
         instance_successful = return_code == 0
         if not instance_successful:
             logging.info(
-                "=== Error occured with return code : {}".format(str(return_code))
+                "=== Error occurred with return code : {}".format(str(return_code))
             )
         return return_code, instance_successful
 
@@ -381,7 +381,7 @@ class FwEntityUpgrader(object):
                         # Otherwise, check if continue_on_error field is set in JSON
                         if self._is_continue_on_error_set_in_json():
                             logging.info(
-                                "=== Error occured with return code : {}".format(
+                                "=== Error occurred with return code : {}".format(
                                     str(return_code)
                                 )
                             )
@@ -432,7 +432,7 @@ class FwEntityUpgrader(object):
             subprocess.check_output(cmd_to_execute, shell=True)  # noqa p204
             return True
         except subprocess.CalledProcessError as e:
-            logging.info("Exception {} occured when running command".format(e))
+            logging.info("Exception {} occurred when running command".format(e))
             return False
 
     def _is_continue_on_error_set_in_json(self) -> bool:


### PR DESCRIPTION
Five log/error messages across two firmware upgrade files read `occured`:

| File | Lines | Context |
|------|-------|---------|
| `tools/fw_upgrade/entity_upgrader.py` | 251, 278, 384, 435 | Exception and error return code messages visible in upgrade logs |
| `tests2/common/base_fw_upgrade_test.py` | 532 | Test log message |

Fixed to `occurred`. String-literal-only change — visible in firmware upgrade output logs.