### PR TITLE
[Nexthop] tools: fboss-lite: Add wrynose to LAYERSERIES_COMPAT

### DIFF
--- a/tools/fboss-lite/fblite-ref-layer/conf/layer.conf
+++ b/tools/fboss-lite/fblite-ref-layer/conf/layer.conf
@@ -25,7 +25,7 @@ BBFILE_COLLECTIONS += "@FBMODEL@"
 BBFILE_PATTERN_@FBMODEL@ = "^${LAYERDIR}/"
 BBFILE_PRIORITY_@FBMODEL@ = "25"
 
-LAYERSERIES_COMPAT_@FBMODEL@ = "whinlatter walnascar styhead scarthgap nanbield kirkstone dunfell"
+LAYERSERIES_COMPAT_@FBMODEL@ = "wrynose whinlatter walnascar styhead scarthgap nanbield kirkstone dunfell"
 
 INIT_MANAGER = "systemd"
 DISTRO_FEATURES:append = " systemd usrmerge"


### PR DESCRIPTION
# Description

Summary:

Add wrynose to the list of LAYERSERIES_COMPAT for the fblite-ref-layer so that new platforms generated by new-fblite.py will build successfully.

# Motivation

New platforms should have the correct set of LAYERSERIES_COMPAT entries so they build without errors.

# Test Plan

Test Plan:

./new-fblite.py -n testbmc
. openbmc-init-build-env testbmc
bitbake testbmc-image

The BitBake command will complete successfully.

