### PR TITLE
acctonbmc: Fix oob-mdio-util.sh write operation

### DIFF
--- a/meta-facebook/meta-acctonbmc/recipes-utils/show-tech/files/oob-mdio-util.sh
+++ b/meta-facebook/meta-acctonbmc/recipes-utils/show-tech/files/oob-mdio-util.sh
@@ -43,7 +43,8 @@ if [ "$mode" = "write" ]; then
         exit 1;
     fi
     ctrl_cmd=$(( 0x9000 | (0x1 << 10) | ( (0x10 + port) << 5) | reg_addr ))
-    data=$3
+    ctrl_cmd=$(printf "0x%08X" "$ctrl_cmd")
+    data=$4
     mdio-util -m "$OOB_MDIO_BUS" -p "$OOB_PHY_ADDR" -w 0x1 -d "$data"
     mdio-util -m "$OOB_MDIO_BUS" -p "$OOB_PHY_ADDR" -w 0x0 -d "$ctrl_cmd"
 elif [ "$mode" = "read" ]; then


### PR DESCRIPTION
# Description

Fix bug in the write operation of oob-mdio-util.sh.

1. `data` is the forth argument, not the third.
2. `ctrl_cmd` must be in hex representation because mdio-util expects it [here](https://github.com/facebook/openbmc/blob/7d8e2aa82d6a619299395208d659b7466b014315/meta-aspeed/recipes-utils/mdio-util/files/mdio-util.c#L381). So, I used `printf "0x%08X"`, similar to [how it's done for the read operation](https://github.com/facebook/openbmc/blob/7d8e2aa82d6a619299395208d659b7466b014315/meta-facebook/meta-acctonbmc/recipes-utils/show-tech/files/oob-mdio-util.sh#L55).

# Motivation

`oob-mdio-util.sh` has a bug when doing a register write to the OOB management switch.

# Test Plan

**Before**:
Note: usage is `oob-mdio-util.sh {read|write} <port> <offset> [<value>]`
```
root@bmc-oob:~# oob-mdio-util.sh read 1 0x7
Write to PHY 0x12.0x0, value is 0x9a27
Read from PHY 0x12.0x1, value is 0x1         # <----- Read: got 0x1

root@bmc-oob:~# oob-mdio-util.sh write 1 0x7 0xabcd
Write to PHY 0x12.0x1, value is 0x7
Write to PHY 0x12.0x0, value is 0x38439      # <----- Write: wrong command was sent. ctrl_cmd supposed to be a 16-bit value

root@bmc-oob:~# oob-mdio-util.sh read 1 0x7
Write to PHY 0x12.0x0, value is 0x9a27
Read from PHY 0x12.0x1, value is 0x1         # <----- Read back: WRONG! Still got 0x1
```

**After**:
```
root@bmc-oob:~# oob-mdio-util.sh read 1 0x7
Write to PHY 0x12.0x0, value is 0x9a27
Read from PHY 0x12.0x1, value is 0x1

root@bmc-oob:~# oob-mdio-util.sh write 1 0x7 0xabcd
Write to PHY 0x12.0x1, value is 0xabcd
Write to PHY 0x12.0x0, value is 0x9627        # <----- Write: correct value of ctrl_cmd

root@bmc-oob:~# oob-mdio-util.sh read 1 0x7
Write to PHY 0x12.0x0, value is 0x9a27
Read from PHY 0x12.0x1, value is 0xabcd       # <----- Read back: GOOD! Got the value we wrote
```
