### PR TITLE
Bound Elbert local MAC address read

### DIFF
--- a/meta-facebook/meta-elbert/recipes-utils/wedge-eeprom/files/utils/elbert_weutil.c
+++ b/meta-facebook/meta-elbert/recipes-utils/wedge-eeprom/files/utils/elbert_weutil.c
@@ -24,15 +24,17 @@
 #include <string.h>
 #define BMC_MGMT_MACADDR "/sys/class/net/eth0/address"
 
-void read_local_mac(char *buffer)
+void read_local_mac(char *buffer, size_t buffer_len)
 {
-  if (!buffer)
+  if (!buffer || buffer_len == 0)
     return;
   FILE *fp;
-  sprintf(buffer, "NA");
+  snprintf(buffer, buffer_len, "NA");
   fp = fopen(BMC_MGMT_MACADDR, "r");
   if (fp){
-     fscanf(fp, "%s", buffer);
+     if (fscanf(fp, "%19s", buffer) != 1) {
+       snprintf(buffer, buffer_len, "NA");
+     }
      fclose(fp);
   }
   return;
@@ -64,7 +66,7 @@ int main(int argc, const char *argv[])
     return -1;
   }
 
-  read_local_mac(local_mac);
+  read_local_mac(local_mac, sizeof(local_mac));
   elbert_parse_mac(parsed_mac,local_mac,0);
 
   printf("Wedge EEPROM %s:\n", fn ? fn : "");


### PR DESCRIPTION
Fixes #126.

This bounds the local MAC address read in `elbert_weutil`:

- passes the destination buffer size into `read_local_mac`
- initializes the fallback value with `snprintf`
- limits the sysfs read to the destination buffer size
- checks the `fscanf` result and preserves the `"NA"` fallback on malformed input

Test plan:

```
git diff --check
```

I did not run a full OpenBMC image build locally because the Yocto/OpenBMC build environment and platform layers are not configured in this workspace.
