### PR TITLE
rest-api: Fix POST error for /api/sys/server and /api/sys/psu_update

### DIFF
--- a/common/recipes-rest/rest-api/files/common_endpoint.py
+++ b/common/recipes-rest/rest-api/files/common_endpoint.py
@@ -32,9 +32,9 @@ import rest_sensors
 import rest_server
 from aiohttp import web
 from common_utils import (
-    common_force_async,
+    RequestContext,
+    async_web_handler_in_common_executor,
     dumps_bytestr,
-    get_data_from_generator,
     get_endpoints,
 )
 
@@ -42,7 +42,7 @@ from common_utils import (
 class commonApp_Handler:
 
     # Handler for root resource endpoint
-    def helper_rest_api(self, request):
+    def helper_rest_api(self, ctx: RequestContext):
         result = {
             "Information": {
                 "Description": "Wedge RESTful API Entry",
@@ -53,12 +53,12 @@ class commonApp_Handler:
         }
         return web.json_response(result, dumps=dumps_bytestr)
 
-    @common_force_async
-    def rest_api(self, request):
-        return self.helper_rest_api(request)
+    @async_web_handler_in_common_executor
+    def rest_api(self, ctx: RequestContext):
+        return self.helper_rest_api(ctx)
 
     # Handler for root resource endpoint
-    def helper_rest_sys(self, request):
+    def helper_rest_sys(self, ctx: RequestContext):
         result = {
             "Information": {"Description": "Wedge System"},
             "Actions": [],
@@ -66,12 +66,12 @@ class commonApp_Handler:
         }
         return web.json_response(result, dumps=dumps_bytestr)
 
-    @common_force_async
-    def rest_sys(self, request):
-        return self.helper_rest_sys(request)
+    @async_web_handler_in_common_executor
+    def rest_sys(self, ctx: RequestContext):
+        return self.helper_rest_sys(ctx)
 
     # Handler for sys/mb resource endpoint
-    def helper_rest_mb_sys(self, request):
+    def helper_rest_mb_sys(self, ctx: RequestContext):
         result = {
             "Information": {"Description": "System Motherboard"},
             "Actions": [],
@@ -79,101 +79,99 @@ class commonApp_Handler:
         }
         return web.json_response(result, dumps=dumps_bytestr)
 
-    @common_force_async
-    def rest_mb_sys(self, request):
-        return self.helper_rest_mb_sys(request)
+    @async_web_handler_in_common_executor
+    def rest_mb_sys(self, ctx: RequestContext):
+        return self.helper_rest_mb_sys(ctx)
 
     # Handler for sys/mb/fruid resource endpoint
-    def helper_rest_fruid_hdl(self, request):
+    def helper_rest_fruid_hdl(self, ctx: RequestContext):
         return web.json_response(rest_fruid.get_fruid(), dumps=dumps_bytestr)
 
-    @common_force_async
-    def rest_fruid_hdl(self, request):
-        return self.helper_rest_fruid_hdl(request)
+    @async_web_handler_in_common_executor
+    def rest_fruid_hdl(self, ctx: RequestContext):
+        return self.helper_rest_fruid_hdl(ctx)
 
     # Handler for sys/mb/fruid resource endpoint
-    def helper_rest_fruid_pim_hdl(self, request):
+    def helper_rest_fruid_pim_hdl(self, ctx: RequestContext):
         return web.json_response(
             rest_fruid_pim.get_fruid(), dumps=dumps_bytestr, status=200
         )
 
-    @common_force_async
-    def rest_fruid_pim_hdl(self, request):
-        return self.helper_rest_fruid_pim_hdl(request)
+    @async_web_handler_in_common_executor
+    def rest_fruid_pim_hdl(self, ctx: RequestContext):
+        return self.helper_rest_fruid_pim_hdl(ctx)
 
     async def rest_bmc_hdl(self, request):
         result = await rest_bmc.get_bmc()
         return web.json_response(result, dumps=dumps_bytestr)
 
     # Handler for sys/server resource endpoint
-    def helper_rest_server_hdl(self, request):
+    def helper_rest_server_hdl(self, ctx: RequestContext):
         return web.json_response(rest_server.get_server(), dumps=dumps_bytestr)
 
-    @common_force_async
-    def rest_server_hdl(self, request):
-        return self.helper_rest_server_hdl(request)
+    @async_web_handler_in_common_executor
+    def rest_server_hdl(self, ctx: RequestContext):
+        return self.helper_rest_server_hdl(ctx)
 
     # Handler for uServer resource endpoint
-    def helper_rest_server_act_hdl(self, request):
-        data = get_data_from_generator(request.json())
+    def helper_rest_server_act_hdl(self, ctx: RequestContext):
         return web.json_response(
-            rest_server.server_action(data), dumps=dumps_bytestr, status=200
+            rest_server.server_action(ctx.json_data), dumps=dumps_bytestr, status=200
         )
 
-    @common_force_async
-    def rest_server_act_hdl(self, request):
-        return self.helper_rest_server_act_hdl(request)
+    @async_web_handler_in_common_executor
+    def rest_server_act_hdl(self, ctx: RequestContext):
+        return self.helper_rest_server_act_hdl(ctx)
 
     # Handler for sensors resource endpoint
-    def helper_rest_sensors_hdl(self, request):
+    def helper_rest_sensors_hdl(self, ctx: RequestContext):
         return web.json_response(
             rest_sensors.get_sensors(), dumps=dumps_bytestr, status=200
         )
 
-    @common_force_async
-    def rest_sensors_hdl(self, request):
-        return self.helper_rest_sensors_hdl(request)
+    @async_web_handler_in_common_executor
+    def rest_sensors_hdl(self, ctx: RequestContext):
+        return self.helper_rest_sensors_hdl(ctx)
 
     # Handler for gpios resource endpoint
-    def helper_rest_gpios_hdl(self, request):
+    def helper_rest_gpios_hdl(self, ctx: RequestContext):
         return web.json_response(
             rest_gpios.get_gpios(), dumps=dumps_bytestr, status=200
         )
 
-    @common_force_async
-    def rest_gpios_hdl(self, request):
-        return self.helper_rest_gpios_hdl(request)
+    @async_web_handler_in_common_executor
+    def rest_gpios_hdl(self, ctx: RequestContext):
+        return self.helper_rest_gpios_hdl(ctx)
 
     # Handler for peer FC presence resource endpoint
-    def helper_rest_fcpresent_hdl(self, request):
+    def helper_rest_fcpresent_hdl(self, ctx: RequestContext):
         return web.json_response(
             rest_fcpresent.get_fcpresent(), dumps=dumps_bytestr, status=200
         )
 
-    @common_force_async
-    def rest_fcpresent_hdl(self, request):
-        return self.helper_rest_fcpresent_hdl(request)
+    @async_web_handler_in_common_executor
+    def rest_fcpresent_hdl(self, ctx: RequestContext):
+        return self.helper_rest_fcpresent_hdl(ctx)
 
     # Handler for psu_update resource endpoint
-    def helper_psu_update_hdl(self, request):
+    def helper_psu_update_hdl(self, ctx: RequestContext):
         return web.json_response(
             rest_psu_update.get_jobs(), dumps=dumps_bytestr, status=200
         )
 
-    @common_force_async
-    def psu_update_hdl(self, request):
-        return self.helper_psu_update_hdl(request)
+    @async_web_handler_in_common_executor
+    def psu_update_hdl(self, ctx: RequestContext):
+        return self.helper_psu_update_hdl(ctx)
 
     # Handler for psu_update resource action
-    def helper_psu_update_hdl_post(self, request):
-        data = get_data_from_generator(request.json())
+    def helper_psu_update_hdl_post(self, ctx: RequestContext):
         return web.json_response(
-            rest_psu_update.begin_job(data), dumps=dumps_bytestr, status=200
+            rest_psu_update.begin_job(ctx.json_data), dumps=dumps_bytestr, status=200
         )
 
-    @common_force_async
-    def psu_update_hdl_post(self, request):
-        return self.helper_psu_update_hdl_post(request)
+    @async_web_handler_in_common_executor
+    def psu_update_hdl_post(self, ctx: RequestContext):
+        return self.helper_psu_update_hdl_post(ctx)
 
     # Handler for additional fscd sensor data
     @staticmethod

--- a/common/recipes-rest/rest-api/files/common_utils.py
+++ b/common/recipes-rest/rest-api/files/common_utils.py
@@ -48,6 +48,7 @@ def async_in_common_executor(func):
     """
 
     async def func_wrapper(*args, **kwargs):
+        # Convert the possibly blocking helper function into async
         return await _run_in_common_executor(func, *args, **kwargs)
 
     return func_wrapper

--- a/common/recipes-rest/rest-api/files/common_utils.py
+++ b/common/recipes-rest/rest-api/files/common_utils.py
@@ -3,7 +3,8 @@ import json
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, List, Optional, Set, Tuple, Union  # noqa: F401
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Set, Tuple, Union  # noqa: F401
 
 from aiohttp import web
 from common_webapp import WebApp
@@ -14,38 +15,65 @@ common_executor = ThreadPoolExecutor(5)
 ENDPOINT_CHILDREN = {}  # type: Dict[str, Set[str]]
 
 
-def common_force_async(func):
-    # common handler will use its own executor (thread based),
-    # we initentionally separated this from the executor of
-    # board-specific REST handler, so that any problem in
-    # common REST handlers will not interfere with board-specific
-    # REST handler, and vice versa
+@dataclass(frozen=True)
+class RequestContext:
+    """Thread-safe, immutable context extracted from an aiohttp request.
+
+    This dataclass captures request data before entering the executor thread,
+    since aiohttp's request object is not thread-safe.
+    """
+
+    method: str
+    path: str
+    json_data: Dict[str, Any]
+
+
+async def _run_in_common_executor(func, *args, **kwargs):
+    # The common REST handlers use their own executor (thread based); this is
+    # intentionally separated from the executor of the board-specific REST
+    # handlers, so that a problem in the common REST handlers will not
+    # interfere with the board-specific handlers, and vice versa.
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(common_executor, func, *args, **kwargs)
+
+
+def async_in_common_executor(func):
+    """Decorator to run a blocking function in the common executor thread pool.
+
+    Use this for standalone functions that do NOT take an aiohttp request as a
+    parameter. The decorated function's arguments are forwarded unchanged.
+
+    For request handlers that need access to the aiohttp request, use
+    `async_web_handler_in_common_executor` instead.
+    """
+
     async def func_wrapper(*args, **kwargs):
-        # Convert the possibly blocking helper function into async
-        loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(common_executor, func, *args, **kwargs)
-        return result
+        return await _run_in_common_executor(func, *args, **kwargs)
 
     return func_wrapper
 
 
-# When we call request.json() in asynchronous function, a generator
-# will be returned. Upon calling next(), the generator will either :
-#
-# 1) return the next data as usual,
-#   - OR -
-# 2) throw StopIteration, with its first argument as the data
-#    (this is for indicating that no more data is available)
-#
-# Not sure why aiohttp's request generator is implemented this way, but
-# the following function will handle both of the cases mentioned above.
-def get_data_from_generator(data_generator):
-    data = None
-    try:
-        data = next(data_generator)
-    except StopIteration as e:
-        data = e.args[0]
-    return data
+def async_web_handler_in_common_executor(func):
+    """Decorator to run a blocking aiohttp handler in the common executor thread pool.
+
+    Use this for request handlers that take an aiohttp request as a parameter.
+    Because the aiohttp request object is not thread-safe, the request is read
+    on the event loop and converted into an immutable, thread-safe
+    RequestContext, which is passed to the handler in place of the request.
+
+    For standalone functions that do not take a request, use `async_in_common_executor`
+    instead.
+    """
+
+    async def func_wrapper(self, request: web.Request, *args, **kwargs):
+        ctx = RequestContext(
+            method=request.method,
+            path=request.path,
+            json_data=await request.json() if request.can_read_body else {},
+        )
+        return await _run_in_common_executor(func, self, ctx, *args, **kwargs)
+
+    return func_wrapper
 
 
 def get_endpoints(path: str):

--- a/common/recipes-rest/rest-api/files/common_utils.py
+++ b/common/recipes-rest/rest-api/files/common_utils.py
@@ -55,14 +55,17 @@ def async_in_common_executor(func):
 
 
 def async_web_handler_in_common_executor(func):
-    """Decorator to run a blocking aiohttp handler in the common executor thread pool.
+    """Decorator for aiohttp endpoint handlers, run in the common executor thread pool.
 
-    Use this for request handlers that take an aiohttp request as a parameter.
-    Because the aiohttp request object is not thread-safe, the request is read
-    on the event loop and converted into an immutable, thread-safe
-    RequestContext, which is passed to the handler in place of the request.
+    Use this for handlers wired up as aiohttp routes (the ones aiohttp invokes
+    with a `web.Request`). Note that the decorated handler does NOT receive the
+    raw request: the decorator reads the request on the event loop and passes a
+    `RequestContext` in its place, so the handler's signature is
+    `(self, ctx: RequestContext)`, not `(self, request)`. This conversion is
+    required because the aiohttp request object is not thread-safe and must not
+    be touched from the executor thread.
 
-    For standalone functions that do not take a request, use `async_in_common_executor`
+    For standalone functions that do not handle a web request, use `async_in_common_executor`
     instead.
     """
 

--- a/common/recipes-rest/rest-api/files/common_utils.py
+++ b/common/recipes-rest/rest-api/files/common_utils.py
@@ -70,10 +70,16 @@ def async_web_handler_in_common_executor(func):
     """
 
     async def func_wrapper(self, request: web.Request, *args, **kwargs):
+        # aiohttp >= 2.3 exposes can_read_body; aiohttp 2.1.0 used on
+        # older distros (rocko/dunfell) only has the equivalent payload check
+        # via `request.content.at_eof()``.
+        can_read_body = getattr(request, "can_read_body", None)
+        if can_read_body is None:
+            can_read_body = not request.content.at_eof()
         ctx = RequestContext(
             method=request.method,
             path=request.path,
-            json_data=await request.json() if request.can_read_body else {},
+            json_data=await request.json() if can_read_body else {},
         )
         return await _run_in_common_executor(func, self, ctx, *args, **kwargs)
 

--- a/common/recipes-rest/rest-api/files/common_utils.py
+++ b/common/recipes-rest/rest-api/files/common_utils.py
@@ -29,10 +29,11 @@ class RequestContext:
 
 
 async def _run_in_common_executor(func, *args, **kwargs):
-    # The common REST handlers use their own executor (thread based); this is
-    # intentionally separated from the executor of the board-specific REST
-    # handlers, so that a problem in the common REST handlers will not
-    # interfere with the board-specific handlers, and vice versa.
+    # common handler will use its own executor (thread based),
+    # we initentionally separated this from the executor of
+    # board-specific REST handler, so that any problem in
+    # common REST handlers will not interfere with board-specific
+    # REST handler, and vice versa
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(common_executor, func, *args, **kwargs)
 

--- a/common/recipes-rest/rest-api/files/redfish_sensors.py
+++ b/common/recipes-rest/rest-api/files/redfish_sensors.py
@@ -7,7 +7,7 @@ import pal
 import redfish_chassis_helper
 import rest_pal_legacy
 from aiohttp import web
-from common_utils import common_force_async, dumps_bytestr, parse_expand_level
+from common_utils import async_in_common_executor, dumps_bytestr, parse_expand_level
 from redfish_base import validate_keys
 
 try:
@@ -99,7 +99,7 @@ async def get_redfish_sensor_handler(request: web.Request) -> web.Response:
     return web.json_response(body, dumps=dumps_bytestr)
 
 
-@common_force_async
+@async_in_common_executor
 def _get_sensor_members(parent_resource: str, fru_names: t.List[str], expand: bool):
     assert _SENSOR_LOCK.locked()
     members_json = []


### PR DESCRIPTION
# Description

Fixes https://github.com/facebook/openbmc/issues/272

1. Fix POST handler error: replace `get_data_from_generator(request.json())` with parsed `ctx.json_data` since aiohttp >= 3.0.0 no longer returns [generator-based couroutine](https://docs.python.org/3.8/library/asyncio-task.html#generator-based-coroutines).
2. Add `RequestContext` dataclass: thread-safe snapshot of RestAPI request payload, captured before entering the executor thread.
3. Add `@async_web_handler_in_common_executor` decorator for request handlers; builds `RequestContext` on the event loop and feeds it to the handlers.
4. Migrate all common_endpoint.py handlers to `(self, ctx: RequestContext)` and use `@async_web_handler_in_common_executor`.
5. Rename `@common_force_async` → `@async_in_common_executor` for non-request functions.
6. Extract `_run_in_common_executor()` helper; unify on `get_running_loop()`.

# Motivation

Calling POST action with JSON data would fail with `TypeError("'coroutine' object is not an iterator")`:
```
root@bmc-oob:~# curl -s -X POST \
  -H "Content-Type: application/json" \
  -d "{\"action\":\"power-on\"}" \
  http://localhost:8080/api/sys/server
{"Information": {"reason": "TypeError(\"'coroutine' object is not an iterator\")"}, "Actions": [], "Resources": []}
```

This is because of the transition from aiohttp 2.3.10 -> aiohttp 3.0.0, where `Request.json()` no longer returns a [generator-based coroutine](https://docs.python.org/3.8/library/asyncio-task.html#generator-based-coroutines) ([v2.3.10](https://github.com/aio-libs/aiohttp/blob/v2.3.10/aiohttp/web_request.py#L509-L510) vs [v3.0.0](https://github.com/aio-libs/aiohttp/blob/v3.0.0/aiohttp/web_request.py#L510)).

However, `/api/sys/server` and `/api/sys/psu_update` endpoints still rely on `get_data_from_generator(request.json())` which assumes a generator-based coroutine. So, instead, we should use `await request.json()` to get the data.

Caveat:
- `rocko` and `dunfell` still use aiohttp 2.1.0, as shown [here](https://github.com/facebook/openbmc/blob/a065660037ea1549f165cb15288aec1ea2fea550/common/recipes-rest/rest-api/rest-api_0.1.bb#L47-L48) ([aiohttp_2.1.0.bb](https://github.com/facebook/openbmc/blob/a065660037ea1549f165cb15288aec1ea2fea550/common/recipes-rest/aiohttp/aiohttp_2.1.0.bb)).
- `kirkstone` and `master` uses `python3-aiohttp` from `meta-openembedded`. As of now:

Yocto branch | Pinned commit (yocto_repos.sh) | aiohttp | evidence
-- | -- | -- | --
lf-kirkstone | 91c406079 | 3.8.1 | [python3-aiohttp_3.8.1.bb](https://github.com/openbmc/openbmc/blob/91c4060797737f563a7b975d726f2efcb088e45f/meta-openembedded/meta-python/recipes-devtools/python/python3-aiohttp_3.8.1.bb)
lf-master | ea1e8642b | 3.13.5 | [python3-aiohttp_3.13.5.bb](https://github.com/openbmc/openbmc/blob/ea1e8642b95a5d04a7c403bae6c17ae6bbe3e1b2/upstream-layers/meta-openembedded/meta-python/recipes-devtools/python/python3-aiohttp_3.13.5.bb)
- `await request.json()` should also work on aiohttp 2.1.0 (confirmed with local testing, using python 3.8 + aiohttp 2.1.0)
- `request.can_read_body()` does not exist in aiohttp 2.1.0, so it is handled separately

# Test Plan

**Before:**
```
root@bmc-oob:~# python3 -c "import aiohttp; print(aiohttp.__version__)"
3.13.5
root@bmc-oob:~# curl -s -X POST \
  -H "Content-Type: application/json" \
  -d "{\"action\":\"power-on\"}" \
  http://localhost:8080/api/sys/server
{"Information": {"reason": "TypeError(\"'coroutine' object is not an iterator\")"}, "Actions": [], "Resources": []}
```

**After:**
```
root@bmc-oob:~# python3 -c "import aiohttp; print(aiohttp.__version__)"
3.13.5
root@bmc-oob:~# curl -s -X POST \
  -H "Content-Type: application/json" \
  -d "{\"action\":\"power-on\"}" \
  http://localhost:8080/api/sys/server
{"result": "failure", "reason": "already on"}
```

- /redfish/v1/Chassis/1/Sensors which has dependency on @async_in_common_executor still work:
```
root@bmc-oob:~# curl http://localhost:8080/redfish/v1/Chassis/1/Sensors
{"@odata.type": "#SensorCollection.SensorCollection", "Name": "Chassis sensors", "Members@odata.count": 0, "Members": [], "@odata.id": "/redfish/v1/Chassis/1/Sensors"}
```