### PR TITLE
Import QEMU patch files that have been accepted for upstream

### DIFF
--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0601-hw-sensor-adc128d818-add-12-bit-8-channel-ADC-device.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0601-hw-sensor-adc128d818-add-12-bit-8-channel-ADC-device.patch
@@ -1,0 +1,801 @@
+From 54a53b965ef7e386e57e265353bd0b4b2fcb5d81 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Tue, 7 Jul 2026 11:15:54 +0200
+Subject: [PATCH 601/631] hw/sensor: adc128d818: add 12-bit 8-channel ADC
+ device
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The ADC128D818 is a TI 12-bit, 8-channel I2C ADC used on several
+OpenBMC platforms for voltage and temperature monitoring.
+
+Implement the device with:
+ - four operating modes
+ - 12-bit voltage conversion from QOM inputs
+ - 9-bit temperature conversion from milli-degree Celsius QOM inputs
+ - switchable internal or external voltage reference
+ - per-channel high/low limit registers
+ - interrupt support
+ - software reset
+ - one-shot conversion support in shutdown mode
+
+Reviewed-by: Alexander Hansen <alexander.hansen@9elements.com>
+Tested-by: Alexander Hansen <alexander.hansen@9elements.com>
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Link: https://lore.kernel.org/qemu-devel/20260707091609.97759-2-emmanuel.blot@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/sensor/Kconfig              |   4 +
+ hw/sensor/adc128d818.c         | 696 +++++++++++++++++++++++++++++++++
+ hw/sensor/meson.build          |   1 +
+ hw/sensor/trace-events         |   8 +
+ include/hw/sensor/adc128d818.h |  14 +
+ 5 files changed, 723 insertions(+)
+ create mode 100644 hw/sensor/adc128d818.c
+ create mode 100644 include/hw/sensor/adc128d818.h
+
+diff --git a/hw/sensor/Kconfig b/hw/sensor/Kconfig
+index bc6331b4abb..b459ac22407 100644
+--- a/hw/sensor/Kconfig
++++ b/hw/sensor/Kconfig
+@@ -1,3 +1,7 @@
++config ADC128D818
++    bool
++    depends on I2C
++
+ config TMP105
+     bool
+     depends on I2C
+diff --git a/hw/sensor/adc128d818.c b/hw/sensor/adc128d818.c
+new file mode 100644
+index 00000000000..c65508cba14
+--- /dev/null
++++ b/hw/sensor/adc128d818.c
+@@ -0,0 +1,696 @@
++/*
++ * Texas Instruments ADC128D818 12-bit 8-channel ADC with I2C interface
++ *
++ * Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
++ *
++ * SPDX-License-Identifier: GPL-2.0-or-later
++ */
++
++#include "qemu/osdep.h"
++#include "qemu/log.h"
++#include "qapi/error.h"
++#include "qapi/visitor.h"
++#include "qom/object.h"
++#include "hw/sensor/adc128d818.h"
++#include "hw/core/irq.h"
++#include "hw/core/qdev-properties.h"
++#include "hw/i2c/i2c.h"
++#include "migration/vmstate.h"
++#include "trace.h"
++
++
++/* Register addresses */
++#define REG_CONFIG              0x00
++#define REG_INT_STATUS          0x01
++#define REG_INT_MASK            0x03
++#define REG_CONV_RATE           0x07
++#define REG_CH_DISABLE          0x08
++#define REG_ONE_SHOT            0x09
++#define REG_DEEP_SHUTDOWN       0x0a
++#define REG_ADV_CONFIG          0x0b
++#define REG_BUSY_STATUS         0x0c
++
++/* Channel Reading Registers (16-bit, read-only) */
++#define REG_CH_READING_BASE     0x20
++#define REG_CH_READING_LAST     0x27
++
++/* Limit Registers (8-bit, read/write) */
++#define REG_LIMIT_BASE          0x2a
++#define REG_LIMIT_LAST          0x39
++
++/* ID Registers (read-only) */
++#define REG_MANUFACTURER_ID     0x3e
++#define REG_REVISION_ID         0x3f
++
++/* Configuration Register (0x00) bitfields */
++#define CONFIG_START            BIT(0)
++#define CONFIG_INT_ENABLE       BIT(1)
++#define CONFIG_INT_CLEAR        BIT(3)
++#define CONFIG_INITIALIZATION   BIT(7)
++#define CONFIG_WR_MASK \
++    (CONFIG_START | CONFIG_INT_ENABLE | CONFIG_INT_CLEAR)
++
++/* Advanced Configuration Register (0x0B) bitfields */
++#define ADV_CONFIG_EXT_REF_EN   BIT(0)
++#define ADV_CONFIG_MODE_SHIFT   1
++#define ADV_CONFIG_MODE_MASK    (0x3 << ADV_CONFIG_MODE_SHIFT)
++#define ADV_CONFIG_WR_MASK \
++    (ADV_CONFIG_EXT_REF_EN | ADV_CONFIG_MODE_MASK)
++
++/* Busy Status Register (0x0C) bitfields */
++#define BUSY_STATUS_NOT_READY   BIT(1)
++
++/* Conversion Rate Register (0x07) bitfields */
++#define CONV_RATE_MASK          0x01
++
++/* Deep Shutdown Register (0x0A) bitfields */
++#define DEEP_SHUTDOWN_EN        0x01
++
++/* Device constants */
++#define ADC128D818_NUM_CHANNELS         8
++#define ADC128D818_NUM_REGS             0x40
++
++#define ADC128D818_INTERNAL_VREF_MV     2560
++#define ADC128D818_MAX_VDD_MV           5500
++#define ADC128D818_MANUFACTURER_ID_VAL  0x01
++#define ADC128D818_REVISION_ID_VAL      0x09
++
++/* ADC resolution */
++#define ADC128D818_ADC_RESOLUTION       4096
++#define ADC128D818_ADC_MAX              4095
++
++/* Temperature: 0.5 deg C per LSb = 500 milli-degrees per LSb */
++#define ADC128D818_TEMP_LSB_MC          500
++#define ADC128D818_TEMP_RAW_MIN         (-256)
++#define ADC128D818_TEMP_RAW_MAX         255
++
++
++OBJECT_DECLARE_SIMPLE_TYPE(ADC128D818State, ADC128D818)
++
++struct ADC128D818State {
++    I2CSlave parent_obj;
++
++    qemu_irq irq;
++
++    uint8_t len;
++    uint8_t pointer;
++    uint8_t rx_byte;
++
++    uint8_t regs[ADC128D818_NUM_REGS];
++    uint16_t channel[ADC128D818_NUM_CHANNELS];
++
++    int16_t ain[ADC128D818_NUM_CHANNELS]; /* mV */
++    int32_t temperature; /* milli-degrees Celsius */
++    uint16_t ext_vref; /* mV, 0 means not connected */
++    bool temp_alarm; /* temperature high-limit alarm latched */
++
++    char *description;
++};
++
++static uint16_t adc128d818_get_vref(const ADC128D818State *s)
++{
++    if (s->regs[REG_ADV_CONFIG] & ADV_CONFIG_EXT_REF_EN) {
++        if (s->ext_vref > 0u) {
++            return s->ext_vref;
++        }
++        qemu_log_mask(LOG_GUEST_ERROR,
++                      "%s: %s: external VREF selected but not"
++                      " connected, falling back to internal\n",
++                      __func__, s->description);
++    }
++
++    return ADC128D818_INTERNAL_VREF_MV;
++}
++
++static uint8_t adc128d818_get_mode(const ADC128D818State *s)
++{
++    return (s->regs[REG_ADV_CONFIG] & ADV_CONFIG_MODE_MASK) >>
++           ADV_CONFIG_MODE_SHIFT;
++}
++
++static bool adc128d818_is_temp_channel(const ADC128D818State *s, unsigned ch)
++{
++    if (ch != 7u) {
++        return false;
++    }
++
++    return adc128d818_get_mode(s) != 1u;
++}
++
++static bool adc128d818_is_reserved_channel(const ADC128D818State *s,
++                                           unsigned ch)
++{
++    switch (adc128d818_get_mode(s)) {
++    case 2u:
++        return ch >= 4u && ch <= 6u;
++    case 3u:
++        return ch == 6u;
++    default:
++        return false;
++    }
++}
++
++static int16_t adc128d818_channel_voltage(const ADC128D818State *s, unsigned ch)
++{
++    switch (adc128d818_get_mode(s)) {
++    case 2u:
++        switch (ch) {
++        case 0u:
++            return (int16_t)(s->ain[0] - s->ain[1]);
++        case 1u:
++            return (int16_t)(s->ain[3] - s->ain[2]);
++        case 2u:
++            return (int16_t)(s->ain[4] - s->ain[5]);
++        case 3u:
++            return (int16_t)(s->ain[7] - s->ain[6]);
++        default:
++            return 0;
++        }
++    case 3u:
++        switch (ch) {
++        case 4u:
++            return (int16_t)(s->ain[4] - s->ain[5]);
++        case 5u:
++            return (int16_t)(s->ain[7] - s->ain[6]);
++        default:
++            return s->ain[ch];
++        }
++    default:
++        return s->ain[ch];
++    }
++}
++
++static void adc128d818_update_irq(ADC128D818State *s)
++{
++    uint8_t cfg = s->regs[REG_CONFIG];
++    uint8_t active;
++    bool level;
++
++    active = s->regs[REG_INT_STATUS] & ~s->regs[REG_INT_MASK];
++
++    /* INT pin is active-low */
++    level = !((cfg & CONFIG_INT_ENABLE) && !(cfg & CONFIG_INT_CLEAR) &&
++              (active != 0u));
++
++    trace_adc128d818_irq(s->description, level);
++    qemu_set_irq(s->irq, level);
++}
++
++static bool adc128d818_monitoring_active(const ADC128D818State *s)
++{
++    if (s->regs[REG_DEEP_SHUTDOWN] & DEEP_SHUTDOWN_EN) {
++        return false;
++    }
++    if (!(s->regs[REG_CONFIG] & CONFIG_START)) {
++        return false;
++    }
++    if (s->regs[REG_CONFIG] & CONFIG_INT_CLEAR) {
++        return false;
++    }
++
++    return true;
++}
++
++static void adc128d818_check_limits(ADC128D818State *s)
++{
++    uint8_t disabled = s->regs[REG_CH_DISABLE];
++    uint8_t int_status = 0u;
++
++    for (unsigned ch = 0u; ch < ADC128D818_NUM_CHANNELS; ch++) {
++        if ((disabled & (1u << ch)) ||
++            adc128d818_is_reserved_channel(s, ch)) {
++            continue;
++        }
++
++        if (adc128d818_is_temp_channel(s, ch)) {
++            int raw = s->temperature / ADC128D818_TEMP_LSB_MC;
++            int thot;
++            int thyst;
++
++            raw = MAX(ADC128D818_TEMP_RAW_MIN,
++                      MIN(ADC128D818_TEMP_RAW_MAX, raw));
++            thot = (int)(int8_t)s->regs[REG_LIMIT_BASE + ch * 2u] * 2;
++            thyst = (int)(int8_t)s->regs[REG_LIMIT_BASE + ch * 2u + 1u] * 2;
++
++            if (raw > thot) {
++                s->temp_alarm = true;
++            } else if (raw <= thyst) {
++                s->temp_alarm = false;
++            }
++            if (s->temp_alarm) {
++                int_status |= (1u << ch);
++            }
++        } else {
++            uint8_t msb = (uint8_t)(s->channel[ch] >> 8u);
++            uint8_t high_lim = s->regs[REG_LIMIT_BASE + ch * 2u];
++            uint8_t low_lim = s->regs[REG_LIMIT_BASE + ch * 2u + 1u];
++
++            if (msb > high_lim || msb <= low_lim) {
++                int_status |= (1u << ch);
++            }
++        }
++    }
++
++    s->regs[REG_INT_STATUS] = int_status;
++    adc128d818_update_irq(s);
++}
++
++static void adc128d818_convert(ADC128D818State *s)
++{
++    uint8_t disabled;
++    uint16_t vref;
++
++    disabled = s->regs[REG_CH_DISABLE];
++    vref = adc128d818_get_vref(s);
++
++    for (unsigned ch = 0u; ch < ADC128D818_NUM_CHANNELS; ch++) {
++        if ((disabled & (1u << ch)) ||
++            adc128d818_is_reserved_channel(s, ch)) {
++            continue;
++        }
++
++        if (adc128d818_is_temp_channel(s, ch)) {
++            int32_t raw = s->temperature / ADC128D818_TEMP_LSB_MC;
++
++            raw =
++                MAX(ADC128D818_TEMP_RAW_MIN, MIN(ADC128D818_TEMP_RAW_MAX, raw));
++            s->channel[ch] = (uint16_t)(((unsigned)raw & 0x1FFu) << 7u);
++        } else {
++            int16_t vin = adc128d818_channel_voltage(s, ch);
++            int32_t dout;
++
++            dout = vin * (int32_t)ADC128D818_ADC_RESOLUTION / vref;
++            dout = MAX(0, MIN((int32_t)ADC128D818_ADC_MAX, dout));
++            s->channel[ch] = (uint16_t)(dout << 4u);
++        }
++
++        trace_adc128d818_convert(s->description, ch, s->channel[ch]);
++    }
++
++    s->regs[REG_BUSY_STATUS] &= ~BUSY_STATUS_NOT_READY;
++
++    adc128d818_check_limits(s);
++}
++
++static uint8_t adc128d818_read_channel(ADC128D818State *s, unsigned ch)
++{
++    uint8_t val;
++
++    if (s->rx_byte == 0u) {
++        val = (uint8_t)(s->channel[ch] >> 8u);
++        trace_adc128d818_read_channel(s->description, ch, s->channel[ch]);
++    } else {
++        val = (uint8_t)(s->channel[ch] & 0xFFu);
++    }
++    s->rx_byte ^= 1u;
++
++    return val;
++}
++
++static uint8_t adc128d818_read_reg(ADC128D818State *s, uint8_t reg)
++{
++    uint8_t val;
++
++    switch (reg) {
++    case REG_INT_STATUS:
++        val = s->regs[REG_INT_STATUS];
++        s->regs[REG_INT_STATUS] = 0x00u;
++        if (adc128d818_monitoring_active(s)) {
++            adc128d818_check_limits(s);
++        } else {
++            adc128d818_update_irq(s);
++        }
++        trace_adc128d818_read(s->description, reg, val);
++        return val;
++    case REG_CONFIG:
++    case REG_INT_MASK:
++    case REG_CONV_RATE:
++    case REG_CH_DISABLE:
++    case REG_ONE_SHOT:
++    case REG_DEEP_SHUTDOWN:
++    case REG_ADV_CONFIG:
++    case REG_BUSY_STATUS:
++    case REG_LIMIT_BASE ... REG_LIMIT_LAST:
++    case REG_MANUFACTURER_ID:
++    case REG_REVISION_ID:
++        trace_adc128d818_read(s->description, reg, s->regs[reg]);
++        return s->regs[reg];
++    case REG_CH_READING_BASE ... REG_CH_READING_LAST:
++        return adc128d818_read_channel(s, reg - REG_CH_READING_BASE);
++    default:
++        qemu_log_mask(LOG_GUEST_ERROR,
++                      "%s: %s: read from undefined register 0x%02x\n",
++                      __func__, s->description, reg);
++        return 0x00u;
++    }
++}
++
++static void adc128d818_write_reg(ADC128D818State *s, uint8_t reg, uint8_t val);
++
++static void adc128d818_reset_regs(ADC128D818State *s)
++{
++    memset(s->regs, 0, sizeof(s->regs));
++    memset(s->channel, 0, sizeof(s->channel));
++    s->temp_alarm = false;
++
++    s->regs[REG_CONFIG] = 0x08u;
++    s->regs[REG_BUSY_STATUS] = 0x02u;
++    s->regs[REG_MANUFACTURER_ID] = ADC128D818_MANUFACTURER_ID_VAL;
++    s->regs[REG_REVISION_ID] = ADC128D818_REVISION_ID_VAL;
++
++    for (unsigned ch = 0u; ch < ADC128D818_NUM_CHANNELS; ch++) {
++        s->regs[REG_LIMIT_BASE + ch * 2u] = 0xFFu;
++    }
++
++    s->pointer = 0x00u;
++    s->len = 0u;
++    s->rx_byte = 0u;
++
++    adc128d818_update_irq(s);
++}
++
++static void adc128d818_write_reg(ADC128D818State *s, uint8_t reg, uint8_t val)
++{
++    trace_adc128d818_write(s->description, reg, val);
++
++    switch (reg) {
++    case REG_CONFIG:
++        if (val & CONFIG_INITIALIZATION) {
++            trace_adc128d818_reset(s->description, "reg");
++            adc128d818_reset_regs(s);
++            break;
++        }
++        s->regs[REG_CONFIG] = val & CONFIG_WR_MASK;
++        if ((val & CONFIG_START) && !(val & CONFIG_INT_CLEAR) &&
++            !(s->regs[REG_DEEP_SHUTDOWN] & DEEP_SHUTDOWN_EN)) {
++            adc128d818_convert(s);
++        }
++        adc128d818_update_irq(s);
++        break;
++    case REG_INT_MASK:
++        s->regs[REG_INT_MASK] = val;
++        adc128d818_update_irq(s);
++        break;
++    case REG_CONV_RATE:
++        if (s->regs[REG_CONFIG] & CONFIG_START) {
++            qemu_log_mask(LOG_GUEST_ERROR,
++                          "%s: %s: CONV_RATE written while running\n",
++                          __func__, s->description);
++            break;
++        }
++        s->regs[REG_CONV_RATE] = val & CONV_RATE_MASK;
++        break;
++    case REG_CH_DISABLE:
++        if (s->regs[REG_CONFIG] & CONFIG_START) {
++            qemu_log_mask(LOG_GUEST_ERROR,
++                          "%s: %s: CH_DISABLE written while running\n",
++                          __func__, s->description);
++            break;
++        }
++        s->regs[REG_CH_DISABLE] = val;
++        memset(s->channel, 0, sizeof(s->channel));
++        s->regs[REG_INT_STATUS] = 0x00u;
++        s->temp_alarm = false;
++        adc128d818_update_irq(s);
++        break;
++    case REG_ONE_SHOT:
++        if (!(s->regs[REG_CONFIG] & CONFIG_START)) {
++            adc128d818_convert(s);
++        }
++        break;
++    case REG_DEEP_SHUTDOWN:
++        if ((val & DEEP_SHUTDOWN_EN) && (s->regs[REG_CONFIG] & CONFIG_START)) {
++            qemu_log_mask(LOG_GUEST_ERROR,
++                          "%s: %s: DEEP_SHUTDOWN set while running\n",
++                          __func__, s->description);
++            break;
++        }
++        s->regs[REG_DEEP_SHUTDOWN] = val & DEEP_SHUTDOWN_EN;
++        break;
++    case REG_ADV_CONFIG:
++        if (s->regs[REG_CONFIG] & CONFIG_START) {
++            qemu_log_mask(LOG_GUEST_ERROR,
++                          "%s: %s: ADV_CONFIG written while running\n",
++                          __func__, s->description);
++            break;
++        }
++        s->regs[REG_ADV_CONFIG] = val & ADV_CONFIG_WR_MASK;
++        memset(s->channel, 0, sizeof(s->channel));
++        s->regs[REG_INT_STATUS] = 0x00u;
++        s->temp_alarm = false;
++        adc128d818_update_irq(s);
++        break;
++    case REG_LIMIT_BASE ... REG_LIMIT_LAST:
++        s->regs[reg] = val;
++        break;
++    case REG_INT_STATUS:
++    case REG_BUSY_STATUS:
++    case REG_MANUFACTURER_ID:
++    case REG_REVISION_ID:
++    case REG_CH_READING_BASE ... REG_CH_READING_LAST:
++        qemu_log_mask(LOG_GUEST_ERROR,
++                      "%s: %s: write to read-only register 0x%02x\n",
++                      __func__, s->description, reg);
++        break;
++    default:
++        qemu_log_mask(LOG_GUEST_ERROR,
++                      "%s: %s: write to undefined register 0x%02x\n",
++                      __func__, s->description, reg);
++        break;
++    }
++}
++
++static uint8_t adc128d818_recv(I2CSlave *i2c)
++{
++    ADC128D818State *s = ADC128D818(i2c);
++
++    return adc128d818_read_reg(s, s->pointer);
++}
++
++static int adc128d818_send(I2CSlave *i2c, uint8_t data)
++{
++    ADC128D818State *s = ADC128D818(i2c);
++
++    if (s->len == 0u) {
++        s->pointer = data;
++        s->len++;
++    } else {
++        adc128d818_write_reg(s, s->pointer, data);
++    }
++
++    return 0;
++}
++
++static int adc128d818_event(I2CSlave *i2c, enum i2c_event event)
++{
++    ADC128D818State *s = ADC128D818(i2c);
++
++    s->len = 0u;
++    s->rx_byte = 0u;
++
++    return 0;
++}
++
++static void adc128d818_get_ain(Object *obj, Visitor *v, const char *name,
++                               void *opaque, Error **errp)
++{
++    ADC128D818State *s = ADC128D818(obj);
++    int64_t value;
++    int ch_num;
++    int rc;
++
++    rc = sscanf(name, "ain%d", &ch_num);
++    if (rc != 1 || ch_num < 0 || ch_num >= (int)ADC128D818_NUM_CHANNELS) {
++        error_setg(errp, "%s: %s: invalid channel '%s'", __func__,
++                   s->description, name);
++        return;
++    }
++
++    value = s->ain[ch_num];
++    visit_type_int(v, name, &value, errp);
++}
++
++static void adc128d818_set_ain(Object *obj, Visitor *v, const char *name,
++                               void *opaque, Error **errp)
++{
++    ADC128D818State *s = ADC128D818(obj);
++    int64_t value;
++    int ch_num;
++    int rc;
++
++    if (!visit_type_int(v, name, &value, errp)) {
++        return;
++    }
++
++    rc = sscanf(name, "ain%d", &ch_num);
++    if (rc != 1 || ch_num < 0 || ch_num >= (int)ADC128D818_NUM_CHANNELS) {
++        error_setg(errp, "%s: %s: invalid channel '%s'", __func__,
++                   s->description, name);
++        return;
++    }
++
++    if (value < INT16_MIN || value > INT16_MAX) {
++        error_setg(errp, "%s: %s: value %" PRId64 " out of range for '%s'",
++                   __func__, s->description, value, name);
++        return;
++    }
++
++    s->ain[ch_num] = (int16_t)value;
++
++    if (adc128d818_monitoring_active(s)) {
++        adc128d818_convert(s);
++    }
++}
++
++static void adc128d818_get_temperature(
++    Object *obj, Visitor *v, const char *name, void *opaque, Error **errp)
++{
++    ADC128D818State *s = ADC128D818(obj);
++    int64_t value = s->temperature;
++
++    visit_type_int(v, name, &value, errp);
++}
++
++static void adc128d818_set_temperature(
++    Object *obj, Visitor *v, const char *name, void *opaque, Error **errp)
++{
++    ADC128D818State *s = ADC128D818(obj);
++    int64_t value;
++
++    if (!visit_type_int(v, name, &value, errp)) {
++        return;
++    }
++
++    if (value < INT32_MIN || value > INT32_MAX) {
++        error_setg(errp, "%s: %s: value %" PRId64 " out of range", __func__,
++                   s->description, value);
++        return;
++    }
++
++    s->temperature = (int32_t)value;
++
++    if (adc128d818_monitoring_active(s)) {
++        adc128d818_convert(s);
++    }
++}
++
++static const VMStateDescription adc128d818_vmstate = {
++    .name = "ADC128D818",
++    .version_id = 0,
++    .minimum_version_id = 0,
++    .fields = (VMStateField[]) {
++        VMSTATE_UINT8(len, ADC128D818State),
++        VMSTATE_UINT8(pointer, ADC128D818State),
++        VMSTATE_UINT8(rx_byte, ADC128D818State),
++        VMSTATE_UINT8_ARRAY(regs, ADC128D818State,
++                            ADC128D818_NUM_REGS),
++        VMSTATE_UINT16_ARRAY(channel, ADC128D818State,
++                             ADC128D818_NUM_CHANNELS),
++        VMSTATE_INT16_ARRAY(ain, ADC128D818State,
++                            ADC128D818_NUM_CHANNELS),
++        VMSTATE_INT32(temperature, ADC128D818State),
++        VMSTATE_UINT16(ext_vref, ADC128D818State),
++        VMSTATE_BOOL(temp_alarm, ADC128D818State),
++        VMSTATE_I2C_SLAVE(parent_obj, ADC128D818State),
++        VMSTATE_END_OF_LIST()
++    }
++};
++
++static void adc128d818_reset_hold(Object *obj, ResetType type)
++{
++    ADC128D818State *s = ADC128D818(obj);
++
++    trace_adc128d818_reset(s->description, "hw");
++    adc128d818_reset_regs(s);
++}
++
++static void adc128d818_get_ext_vref(
++    Object *obj, Visitor *v, const char *name, void *opaque, Error **errp)
++{
++    ADC128D818State *s = ADC128D818(obj);
++    int64_t value = (int64_t)s->ext_vref;
++
++    visit_type_int(v, name, &value, errp);
++}
++
++static void adc128d818_set_ext_vref(
++    Object *obj, Visitor *v, const char *name, void *opaque, Error **errp)
++{
++    ADC128D818State *s = ADC128D818(obj);
++    int64_t value;
++
++    if (!visit_type_int(v, name, &value, errp)) {
++        return;
++    }
++
++    if (value < 0 || value > ADC128D818_MAX_VDD_MV) {
++        error_setg(errp,
++                   "%s: %s: ext-vref-mv %" PRId64 " out of range (0..%u mV)",
++                   __func__, s->description, value, ADC128D818_MAX_VDD_MV);
++        return;
++    }
++
++    s->ext_vref = (uint16_t)value;
++
++    if (adc128d818_monitoring_active(s)) {
++        adc128d818_convert(s);
++    }
++}
++
++static void adc128d818_initfn(Object *obj)
++{
++    for (unsigned ch = 0u; ch < ADC128D818_NUM_CHANNELS; ch++) {
++        char *name = g_strdup_printf("ain%u", ch);
++
++        object_property_add(obj, name, "int", adc128d818_get_ain,
++                            adc128d818_set_ain, NULL, NULL);
++        g_free(name);
++    }
++
++    object_property_add(obj, "temperature", "int", adc128d818_get_temperature,
++                        adc128d818_set_temperature, NULL, NULL);
++    object_property_add(obj, "ext-vref-mv", "int", adc128d818_get_ext_vref,
++                        adc128d818_set_ext_vref, NULL, NULL);
++}
++
++static void adc128d818_realize(DeviceState *dev, Error **errp)
++{
++    ADC128D818State *s = ADC128D818(dev);
++
++    if (!s->description) {
++        s->description = g_strdup(object_get_typename(OBJECT(dev)));
++    }
++
++    qdev_init_gpio_out(dev, &s->irq, 1u);
++}
++
++static const Property adc128d818_properties[] = {
++    DEFINE_PROP_STRING("description", ADC128D818State, description),
++};
++
++static void adc128d818_class_init(ObjectClass *klass, const void *data)
++{
++    DeviceClass *dc = DEVICE_CLASS(klass);
++    I2CSlaveClass *ic = I2C_SLAVE_CLASS(klass);
++    ResettableClass *rc = RESETTABLE_CLASS(klass);
++
++    ic->event = adc128d818_event;
++    ic->recv = adc128d818_recv;
++    ic->send = adc128d818_send;
++    dc->realize = adc128d818_realize;
++    rc->phases.hold = adc128d818_reset_hold;
++    dc->vmsd = &adc128d818_vmstate;
++    device_class_set_props(dc, adc128d818_properties);
++}
++
++static const TypeInfo adc128d818_types[] = {
++    {
++        .name          = TYPE_ADC128D818,
++        .parent        = TYPE_I2C_SLAVE,
++        .instance_init = adc128d818_initfn,
++        .instance_size = sizeof(ADC128D818State),
++        .class_init    = adc128d818_class_init,
++    },
++};
++
++DEFINE_TYPES(adc128d818_types)
+diff --git a/hw/sensor/meson.build b/hw/sensor/meson.build
+index 420fdc33592..fe36c9ef910 100644
+--- a/hw/sensor/meson.build
++++ b/hw/sensor/meson.build
+@@ -1,3 +1,4 @@
++system_ss.add(when: 'CONFIG_ADC128D818', if_true: files('adc128d818.c'))
+ system_ss.add(when: 'CONFIG_TMP105', if_true: files('tmp105.c'))
+ system_ss.add(when: 'CONFIG_TMP421', if_true: files('tmp421.c'))
+ system_ss.add(when: 'CONFIG_DPS310', if_true: files('dps310.c'))
+diff --git a/hw/sensor/trace-events b/hw/sensor/trace-events
+index a3fe54fa6dc..5a3630f7bbd 100644
+--- a/hw/sensor/trace-events
++++ b/hw/sensor/trace-events
+@@ -1,5 +1,13 @@
+ # See docs/devel/tracing.rst for syntax documentation.
+ 
++# adc128d818.c
++adc128d818_read(const char *id, uint8_t reg, uint8_t value) "%s reg 0x%02x val 0x%02x"
++adc128d818_read_channel(const char *id, uint8_t channel, uint16_t value) "%s ch %u val 0x%04x"
++adc128d818_write(const char *id, uint8_t reg, uint8_t value) "%s reg 0x%02x val 0x%02x"
++adc128d818_convert(const char *id, uint8_t channel, uint16_t value) "%s ch %u val 0x%04x"
++adc128d818_irq(const char *id, bool level) "%s level %u"
++adc128d818_reset(const char *id, const char *source) "%s %s"
++
+ # tmp105.c
+ tmp105_read(uint8_t dev, uint8_t addr) "device: 0x%02x, addr: 0x%02x"
+ tmp105_write(uint8_t dev, uint8_t addr) "device: 0x%02x, addr 0x%02x"
+diff --git a/include/hw/sensor/adc128d818.h b/include/hw/sensor/adc128d818.h
+new file mode 100644
+index 00000000000..10c34b96464
+--- /dev/null
++++ b/include/hw/sensor/adc128d818.h
+@@ -0,0 +1,14 @@
++/*
++ * Texas Instruments ADC128D818 12-bit 8-channel ADC with I2C interface
++ *
++ * Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
++ *
++ * SPDX-License-Identifier: GPL-2.0-or-later
++ */
++
++#ifndef HW_SENSOR_ADC128D818_H
++#define HW_SENSOR_ADC128D818_H
++
++#define TYPE_ADC128D818 "adc128d818"
++
++#endif
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0602-tests-qtest-adc128d818-add-test-harness-and-register.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0602-tests-qtest-adc128d818-add-test-harness-and-register.patch
@@ -1,0 +1,213 @@
+From f26d21dea2389cd956c99dcb94e7c68b226830e7 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Tue, 7 Jul 2026 11:15:55 +0200
+Subject: [PATCH 602/631] tests/qtest: adc128d818: add test harness and
+ register access
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Introduce the QOS test node and QMP property helpers for the
+ADC128D818, and cover basic register access: manufacturer and
+revision IDs, power-on-reset defaults, software reset, and the
+ain and temperature property readback.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Link: https://lore.kernel.org/qemu-devel/20260707091609.97759-3-emmanuel.blot@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/adc128d818-test.c | 169 ++++++++++++++++++++++++++++++++++
+ tests/qtest/meson.build       |   1 +
+ 2 files changed, 170 insertions(+)
+ create mode 100644 tests/qtest/adc128d818-test.c
+
+diff --git a/tests/qtest/adc128d818-test.c b/tests/qtest/adc128d818-test.c
+new file mode 100644
+index 00000000000..9a8811256f6
+--- /dev/null
++++ b/tests/qtest/adc128d818-test.c
+@@ -0,0 +1,169 @@
++/*
++ * QTest testcase for the ADC128D818 ADC
++ *
++ * Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
++ *
++ * SPDX-License-Identifier: GPL-2.0-or-later
++ */
++
++#include "qemu/osdep.h"
++#include "qemu/bitops.h"
++#include "libqos/i2c.h"
++#include "libqos/qgraph.h"
++#include "libqtest-single.h"
++#include "qobject/qdict.h"
++
++#define ADC128D818_TEST_ID      "adc128d818-test"
++#define ADC128D818_TEST_ADDR    0x1f
++
++/* Register addresses */
++#define REG_CONFIG              0x00
++#define REG_INT_STATUS          0x01
++#define REG_INT_MASK            0x03
++#define REG_CONV_RATE           0x07
++#define REG_CH_DISABLE          0x08
++#define REG_ONE_SHOT            0x09
++#define REG_DEEP_SHUTDOWN       0x0a
++#define REG_ADV_CONFIG          0x0b
++#define REG_BUSY_STATUS         0x0c
++
++/* Channel Reading Registers (16-bit, read-only) */
++#define REG_CH_READING_BASE     0x20
++
++/* Limit Registers (8-bit, read/write) */
++#define REG_LIMIT_BASE          0x2a
++
++/* ID Registers (read-only) */
++#define REG_MANUFACTURER_ID     0x3e
++#define REG_REVISION_ID         0x3f
++
++/* Configuration Register (0x00) bitfields */
++#define CONFIG_START            BIT(0)
++#define CONFIG_INT_ENABLE       BIT(1)
++#define CONFIG_INT_CLEAR        BIT(3)
++#define CONFIG_INITIALIZATION   BIT(7)
++
++/* Advanced Configuration Register (0x0b) bitfields */
++#define ADV_CONFIG_EXT_REF_EN   BIT(0)
++#define ADV_CONFIG_MODE_1       (1 << 1)
++#define ADV_CONFIG_MODE_2       (2 << 1)
++#define ADV_CONFIG_MODE_3       (3 << 1)
++
++/* Number of channels */
++#define NUM_CHANNELS            8
++
++/* Internal VREF in mV */
++#define INTERNAL_VREF_MV        2560
++
++/* QMP helpers for setting device properties */
++
++static void qmp_adc128d818_set(const char *property, int value)
++{
++    QDict *resp;
++
++    resp = qmp("{ 'execute': 'qom-set', 'arguments':"
++               " { 'path': %s, 'property': %s, 'value': %d } }",
++               ADC128D818_TEST_ID, property, value);
++    g_assert(qdict_haskey(resp, "return"));
++    qobject_unref(resp);
++}
++
++static int qmp_adc128d818_get(const char *property)
++{
++    QDict *resp;
++    int ret;
++
++    resp = qmp("{ 'execute': 'qom-get', 'arguments':"
++               " { 'path': %s, 'property': %s } }",
++               ADC128D818_TEST_ID, property);
++    g_assert(qdict_haskey(resp, "return"));
++    ret = qdict_get_int(resp, "return");
++    qobject_unref(resp);
++    return ret;
++}
++
++/* Manufacturer and Revision ID registers */
++static void test_id_registers(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    g_assert_cmphex(i2c_get8(dev, REG_MANUFACTURER_ID), ==, 0x01);
++    g_assert_cmphex(i2c_get8(dev, REG_REVISION_ID), ==, 0x09);
++}
++
++/* Power-on-reset default values */
++static void test_defaults(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    unsigned ch;
++
++    g_assert_cmphex(i2c_get8(dev, REG_CONFIG), ==, 0x08);
++    g_assert_cmphex(i2c_get8(dev, REG_INT_STATUS), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, REG_INT_MASK), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, REG_CONV_RATE), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, REG_CH_DISABLE), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, REG_DEEP_SHUTDOWN), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, REG_ADV_CONFIG), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, REG_BUSY_STATUS), ==, 0x02);
++
++    for (ch = 0u; ch < NUM_CHANNELS; ch++) {
++        g_assert_cmphex(i2c_get8(dev, REG_LIMIT_BASE + ch * 2u), ==, 0xFF);
++        g_assert_cmphex(i2c_get8(dev, REG_LIMIT_BASE + ch * 2u + 1u), ==, 0x00);
++    }
++}
++
++/* Software reset via INITIALIZATION bit */
++static void test_soft_reset(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    i2c_set8(dev, REG_INT_MASK, 0xAA);
++    i2c_set8(dev, REG_CH_DISABLE, 0x55);
++    i2c_set8(dev, REG_LIMIT_BASE, 0x42);
++
++    g_assert_cmphex(i2c_get8(dev, REG_INT_MASK), ==, 0xAA);
++    g_assert_cmphex(i2c_get8(dev, REG_CH_DISABLE), ==, 0x55);
++    g_assert_cmphex(i2c_get8(dev, REG_LIMIT_BASE), ==, 0x42);
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++
++    g_assert_cmphex(i2c_get8(dev, REG_CONFIG), ==, 0x08);
++    g_assert_cmphex(i2c_get8(dev, REG_INT_MASK), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, REG_CH_DISABLE), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, REG_LIMIT_BASE), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, REG_BUSY_STATUS), ==, 0x02);
++}
++
++/* Verify ain property readback via QMP */
++static void test_ain_property(void *obj, void *data, QGuestAllocator *alloc)
++{
++    int value;
++
++    qmp_adc128d818_set("ain3", 1500);
++    value = qmp_adc128d818_get("ain3");
++    g_test_message("Set ain3 = 1500 mV, readback = %d mV", value);
++    g_assert_cmpint(value, ==, 1500);
++
++    qmp_adc128d818_set("temperature", 37500);
++    value = qmp_adc128d818_get("temperature");
++    g_test_message("Set temperature = 37500 mC, readback = %d mC", value);
++    g_assert_cmpint(value, ==, 37500);
++}
++
++static void adc128d818_register_nodes(void)
++{
++    QOSGraphEdgeOptions opts = {
++        .extra_device_opts = "id=" ADC128D818_TEST_ID
++                             ",address=0x1f"
++    };
++    add_qi2c_address(&opts, &(QI2CAddress) { ADC128D818_TEST_ADDR });
++
++    qos_node_create_driver("adc128d818", i2c_device_create);
++    qos_node_consumes("adc128d818", "i2c-bus", &opts);
++
++    qos_add_test("id-registers", "adc128d818", test_id_registers, NULL);
++    qos_add_test("defaults", "adc128d818", test_defaults, NULL);
++    qos_add_test("soft-reset", "adc128d818", test_soft_reset, NULL);
++    qos_add_test("ain-property", "adc128d818", test_ain_property, NULL);
++}
++libqos_init(adc128d818_register_nodes);
+diff --git a/tests/qtest/meson.build b/tests/qtest/meson.build
+index 56ff860e216..5e1fc597e6d 100644
+--- a/tests/qtest/meson.build
++++ b/tests/qtest/meson.build
+@@ -304,6 +304,7 @@ qtests_hexagon = ['boot-serial-test']
+ qos_test_ss = ss.source_set()
+ qos_test_ss.add(
+   'ac97-test.c',
++  'adc128d818-test.c',
+   'adm1272-test.c',
+   'adm1266-test.c',
+   'ds1338-test.c',
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0603-tests-qtest-adc128d818-test-voltage-and-temperature-.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0603-tests-qtest-adc128d818-test-voltage-and-temperature-.patch
@@ -1,0 +1,229 @@
+From d2ec848fbd187d2e5bb1fd58a391914ce38035e7 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Tue, 7 Jul 2026 11:15:56 +0200
+Subject: [PATCH 603/631] tests/qtest: adc128d818: test voltage and temperature
+ conversion
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Cover single-ended voltage conversion across all channels, voltage
+and temperature boundary and clamping cases, and scaling against an
+external voltage reference.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Link: https://lore.kernel.org/qemu-devel/20260707091609.97759-4-emmanuel.blot@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/adc128d818-test.c | 189 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 189 insertions(+)
+
+diff --git a/tests/qtest/adc128d818-test.c b/tests/qtest/adc128d818-test.c
+index 9a8811256f6..891189f0bd8 100644
+--- a/tests/qtest/adc128d818-test.c
++++ b/tests/qtest/adc128d818-test.c
+@@ -150,6 +150,186 @@ static void test_ain_property(void *obj, void *data, QGuestAllocator *alloc)
+     g_assert_cmpint(value, ==, 37500);
+ }
+ 
++/* Voltage conversion */
++static void test_voltage_conversion(void *obj, void *data,
++                                    QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    qmp_adc128d818_set("ain0", 1280);
++    g_test_message("Injected ain0 = 1280 mV");
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Read ch0: raw 0x%04x -> %u mV", reading,
++             (reading >> 4u) * INTERNAL_VREF_MV / 4096u);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    qmp_adc128d818_set("ain1", 2560);
++    g_test_message("Injected ain1 = 2560 mV");
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 1u);
++    g_test_message("Read ch1: raw 0x%04x -> %u mV", reading,
++             (reading >> 4u) * INTERNAL_VREF_MV / 4096u);
++    g_assert_cmphex(reading, ==, 0xFFF0);
++
++    qmp_adc128d818_set("ain2", 0);
++    g_test_message("Injected ain2 = 0 mV");
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 2u);
++    g_test_message("Read ch2: raw 0x%04x -> %u mV", reading,
++             (reading >> 4u) * INTERNAL_VREF_MV / 4096u);
++    g_assert_cmphex(reading, ==, 0x0000);
++}
++
++/* Temperature conversion (mode 0, channel 7 = temperature) */
++static void
++test_temperature_conversion(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    qmp_adc128d818_set("temperature", 25000);
++    g_test_message("Injected temperature = 25000 mC (25.0 deg C)");
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 7u);
++    g_test_message("Read ch7: raw 0x%04x -> %d mC", reading,
++             (int16_t)(reading & 0xFF80u) * 500 / 128);
++    g_assert_cmphex(reading, ==, 0x1900);
++}
++
++/* Channels with distinct voltages */
++static void test_all_channels(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    static const uint16_t ain_mv[NUM_CHANNELS] = {
++        0, 320, 640, 960, 1280, 1920, 2240, 2560
++    };
++    static const uint16_t expect[NUM_CHANNELS] = {
++        0x0000, 0x2000, 0x4000, 0x6000, 0x8000, 0xC000, 0xE000, 0xFFF0
++    };
++    uint16_t reading;
++    unsigned ch;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++    i2c_set8(dev, REG_ADV_CONFIG, ADV_CONFIG_MODE_1);
++
++    for (ch = 0u; ch < NUM_CHANNELS; ch++) {
++        char name[8];
++        snprintf(name, sizeof(name), "ain%u", ch);
++        qmp_adc128d818_set(name, ain_mv[ch]);
++    }
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    for (ch = 0u; ch < NUM_CHANNELS; ch++) {
++        reading = i2c_get16(dev, REG_CH_READING_BASE + ch);
++        g_test_message("ch%u: ain %u mV -> raw 0x%04x (expect 0x%04x)",
++                 ch, ain_mv[ch], reading, expect[ch]);
++        g_assert_cmphex(reading, ==, expect[ch]);
++    }
++}
++
++/* Voltage conversion edge cases */
++static void test_voltage_edges(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++    i2c_set8(dev, REG_ADV_CONFIG, ADV_CONFIG_MODE_1);
++
++    qmp_adc128d818_set("ain0", 3000);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Over-range 3000 mV: raw 0x%04x (expect 0xFFF0)", reading);
++    g_assert_cmphex(reading, ==, 0xFFF0);
++
++    qmp_adc128d818_set("ain1", 1);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 1u);
++    g_test_message("1 mV: raw 0x%04x (expect 0x0010)", reading);
++    g_assert_cmphex(reading, ==, 0x0010);
++
++    qmp_adc128d818_set("ain2", 640);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 2u);
++    g_test_message("640 mV (quarter): raw 0x%04x (expect 0x4000)", reading);
++    g_assert_cmphex(reading, ==, 0x4000);
++
++    qmp_adc128d818_set("ain3", 1920);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 3u);
++    g_test_message("1920 mV (3/4): raw 0x%04x (expect 0xC000)", reading);
++    g_assert_cmphex(reading, ==, 0xC000);
++}
++
++/* Temperature conversion edge cases */
++static void test_temperature_edges(void *obj, void *data,
++                                   QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++
++    qmp_adc128d818_set("temperature", 0);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 7u);
++    g_test_message("0 C: raw 0x%04x (expect 0x0000)", reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++
++    qmp_adc128d818_set("temperature", -25000);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 7u);
++    g_test_message("-25 C: raw 0x%04x (expect 0xE700)", reading);
++    g_assert_cmphex(reading, ==, 0xE700);
++
++    qmp_adc128d818_set("temperature", 127500);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 7u);
++    g_test_message("+127.5 C: raw 0x%04x (expect 0x7F80)", reading);
++    g_assert_cmphex(reading, ==, 0x7F80);
++
++    qmp_adc128d818_set("temperature", -128000);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 7u);
++    g_test_message("-128 C: raw 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    qmp_adc128d818_set("temperature", 200000);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 7u);
++    g_test_message("200 C (clamped): raw 0x%04x (expect 0x7F80)", reading);
++    g_assert_cmphex(reading, ==, 0x7F80);
++
++    qmp_adc128d818_set("temperature", -200000);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 7u);
++    g_test_message("-200 C (clamped): raw 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++}
++
++/* External voltage reference */
++static void test_ext_vref(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++    i2c_set8(dev, REG_ADV_CONFIG, ADV_CONFIG_MODE_1);
++
++    qmp_adc128d818_set("ext-vref-mv", 4096);
++    i2c_set8(dev, REG_ADV_CONFIG, ADV_CONFIG_EXT_REF_EN | ADV_CONFIG_MODE_1);
++
++    qmp_adc128d818_set("ain0", 1000);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("1000 mV / 4096 mV VREF: raw 0x%04x (expect 0x3E80)",
++                   reading);
++    g_assert_cmphex(reading, ==, 0x3E80);
++
++    qmp_adc128d818_set("ain1", 2048);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 1u);
++    g_test_message("2048 mV / 4096 mV VREF: raw 0x%04x (expect 0x8000)",
++                   reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++}
++
+ static void adc128d818_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -165,5 +345,14 @@ static void adc128d818_register_nodes(void)
+     qos_add_test("defaults", "adc128d818", test_defaults, NULL);
+     qos_add_test("soft-reset", "adc128d818", test_soft_reset, NULL);
+     qos_add_test("ain-property", "adc128d818", test_ain_property, NULL);
++    qos_add_test("voltage-conversion", "adc128d818", test_voltage_conversion,
++                 NULL);
++    qos_add_test("temperature-conversion", "adc128d818",
++                 test_temperature_conversion, NULL);
++    qos_add_test("all-channels", "adc128d818", test_all_channels, NULL);
++    qos_add_test("voltage-edges", "adc128d818", test_voltage_edges, NULL);
++    qos_add_test("temperature-edges", "adc128d818", test_temperature_edges,
++                 NULL);
++    qos_add_test("ext-vref", "adc128d818", test_ext_vref, NULL);
+ }
+ libqos_init(adc128d818_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0604-tests-qtest-adc128d818-test-limit-interrupts.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0604-tests-qtest-adc128d818-test-limit-interrupts.patch
@@ -1,0 +1,160 @@
+From e46f41e6475d057f3327622fbb76ea74900ec77a Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Tue, 7 Jul 2026 11:15:57 +0200
+Subject: [PATCH 604/631] tests/qtest: adc128d818: test limit interrupts
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Cover per-channel high- and low-limit interrupt status, the
+INT_CLEAR bit gating the monitoring loop, and the temperature
+high-limit alarm with hysteresis.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Link: https://lore.kernel.org/qemu-devel/20260707091609.97759-5-emmanuel.blot@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/adc128d818-test.c | 121 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 121 insertions(+)
+
+diff --git a/tests/qtest/adc128d818-test.c b/tests/qtest/adc128d818-test.c
+index 891189f0bd8..3e3fabb8d9f 100644
+--- a/tests/qtest/adc128d818-test.c
++++ b/tests/qtest/adc128d818-test.c
+@@ -330,6 +330,123 @@ static void test_ext_vref(void *obj, void *data, QGuestAllocator *alloc)
+     g_assert_cmphex(reading, ==, 0x8000);
+ }
+ 
++/* Interrupt status set on limit violation; persists while fault remains */
++static void test_interrupt_status(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint8_t status;
++
++    i2c_set8(dev, REG_LIMIT_BASE, 0x10);
++    g_test_message("Set ch0 high limit = 0x10");
++
++    qmp_adc128d818_set("ain0", 2560);
++    g_test_message("Injected ain0 = 2560 mV (exceeds limit)");
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_START | CONFIG_INT_ENABLE);
++
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("INT_STATUS = 0x%02x (expect bit 0 set)", status);
++    g_assert_cmphex(status & 0x01u, ==, 0x01);
++
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("INT_STATUS after re-read = 0x%02x (expect bit 0 still set)",
++             status);
++    g_assert_cmphex(status & 0x01u, ==, 0x01);
++
++    qmp_adc128d818_set("ain0", 80);
++    g_test_message("Injected ain0 = 80 mV (within limit)");
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("INT_STATUS after fault cleared = 0x%02x "
++                   "(expect bit 0 clear)", status);
++    g_assert_cmphex(status & 0x01u, ==, 0x00);
++}
++
++/* INT_CLEAR stops the round-robin monitoring loop */
++static void test_int_clear(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint8_t status;
++
++    i2c_set8(dev, REG_LIMIT_BASE, 0x10);
++    qmp_adc128d818_set("ain0", 2560);
++
++    i2c_set8(dev, REG_CONFIG,
++             CONFIG_START | CONFIG_INT_ENABLE | CONFIG_INT_CLEAR);
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("INT_STATUS with INT_CLEAR set = 0x%02x (expect 0x00)",
++                   status);
++    g_assert_cmphex(status, ==, 0x00);
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_START | CONFIG_INT_ENABLE);
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("INT_STATUS after INT_CLEAR cleared = 0x%02x (expect bit 0)",
++             status);
++    g_assert_cmphex(status & 0x01u, ==, 0x01);
++}
++
++/* Low-limit interrupt triggers correctly */
++static void test_low_limit(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint8_t status;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++
++    i2c_set8(dev, REG_LIMIT_BASE + 3u, 0x80);
++    g_test_message("Set ch1 low limit = 0x80");
++
++    i2c_set8(dev, REG_LIMIT_BASE + 5u, 0x80);
++    g_test_message("Set ch2 low limit = 0x80");
++
++    qmp_adc128d818_set("ain1", 640);
++    qmp_adc128d818_set("ain2", 1280);
++    qmp_adc128d818_set("ain0", 1280);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START | CONFIG_INT_ENABLE);
++
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("INT_STATUS = 0x%02x (expect bits 1 and 2 set)", status);
++    g_assert_cmphex(status & 0x02u, ==, 0x02);
++    g_assert_cmphex(status & 0x04u, ==, 0x04);
++
++    g_assert_cmphex(status & 0x01u, ==, 0x00);
++}
++
++/* Temperature high-limit interrupt with hysteresis */
++static void test_temp_hysteresis(void *obj, void *data,
++                                 QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint8_t status;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++
++    i2c_set8(dev, REG_LIMIT_BASE + 7u * 2u, 0x32);
++    i2c_set8(dev, REG_LIMIT_BASE + 7u * 2u + 1u, 0x28);
++
++    qmp_adc128d818_set("temperature", 25000);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("25 C: INT_STATUS = 0x%02x (temp bit expect clear)", status);
++    g_assert_cmphex(status & 0x80u, ==, 0x00);
++
++    qmp_adc128d818_set("temperature", 55000);
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("55 C: INT_STATUS = 0x%02x (temp bit expect set)", status);
++    g_assert_cmphex(status & 0x80u, ==, 0x80);
++
++    qmp_adc128d818_set("temperature", 45000);
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("45 C (hysteresis): INT_STATUS = 0x%02x "
++                   "(temp bit expect set)", status);
++    g_assert_cmphex(status & 0x80u, ==, 0x80);
++
++    qmp_adc128d818_set("temperature", 35000);
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("35 C: INT_STATUS = 0x%02x (temp bit expect clear)", status);
++    g_assert_cmphex(status & 0x80u, ==, 0x00);
++}
++
+ static void adc128d818_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -354,5 +471,9 @@ static void adc128d818_register_nodes(void)
+     qos_add_test("temperature-edges", "adc128d818", test_temperature_edges,
+                  NULL);
+     qos_add_test("ext-vref", "adc128d818", test_ext_vref, NULL);
++    qos_add_test("interrupt-status", "adc128d818", test_interrupt_status, NULL);
++    qos_add_test("int-clear", "adc128d818", test_int_clear, NULL);
++    qos_add_test("low-limit", "adc128d818", test_low_limit, NULL);
++    qos_add_test("temp-hysteresis", "adc128d818", test_temp_hysteresis, NULL);
+ }
+ libqos_init(adc128d818_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0605-tests-qtest-adc128d818-test-operating-modes-and-powe.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0605-tests-qtest-adc128d818-test-operating-modes-and-powe.patch
@@ -1,0 +1,418 @@
+From 44de19d126ba64226ad0a58007547ea0e53322c0 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Tue, 7 Jul 2026 11:15:58 +0200
+Subject: [PATCH 605/631] tests/qtest: adc128d818: test operating modes and
+ power control
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Cover advanced-configuration mode selection (single-ended,
+pseudo-differential pairs, and mixed) and the reset of readings on
+reconfiguration, plus channel disable, one-shot conversion, deep
+shutdown, BUSY_STATUS lifecycle, and conversion-rate gating.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Link: https://lore.kernel.org/qemu-devel/20260707091609.97759-6-emmanuel.blot@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/adc128d818-test.c | 377 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 377 insertions(+)
+
+diff --git a/tests/qtest/adc128d818-test.c b/tests/qtest/adc128d818-test.c
+index 3e3fabb8d9f..91eda5ca74d 100644
+--- a/tests/qtest/adc128d818-test.c
++++ b/tests/qtest/adc128d818-test.c
+@@ -447,6 +447,368 @@ static void test_temp_hysteresis(void *obj, void *data,
+     g_assert_cmphex(status & 0x80u, ==, 0x00);
+ }
+ 
++/* Channel disable prevents conversion */
++static void test_channel_disable(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_CH_DISABLE, 0x01);
++    g_test_message("Disabled channel 0");
++
++    qmp_adc128d818_set("ain0", 1280);
++    g_test_message("Injected ain0 = 1280 mV (disabled)");
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Read ch0 (disabled): raw 0x%04x", reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++
++    qmp_adc128d818_set("ain1", 1280);
++    g_test_message("Injected ain1 = 1280 mV (enabled)");
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 1u);
++    g_test_message("Read ch1 (enabled): raw 0x%04x -> %u mV", reading,
++             (reading >> 4u) * INTERNAL_VREF_MV / 4096u);
++    g_assert_cmphex(reading, ==, 0x8000);
++}
++
++/* One-shot conversion in shutdown mode */
++static void test_one_shot(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    qmp_adc128d818_set("ain0", 1280);
++    g_test_message("Injected ain0 = 1280 mV (device stopped)");
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Read ch0 before one-shot: raw 0x%04x", reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++
++    g_assert_cmphex(i2c_get8(dev, REG_ONE_SHOT), ==, 0x00);
++
++    i2c_set8(dev, REG_ONE_SHOT, 0x00);
++    g_test_message("Triggered one-shot conversion with value 0x00");
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Read ch0 after one-shot: raw 0x%04x -> %u mV", reading,
++             (reading >> 4u) * INTERNAL_VREF_MV / 4096u);
++    g_assert_cmphex(reading, ==, 0x8000);
++}
++
++/* Mode 1 makes channel 7 a voltage input instead of temperature */
++static void test_mode_selection(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_ADV_CONFIG, ADV_CONFIG_MODE_1);
++    g_test_message("Set mode 1 (all voltage channels)");
++
++    qmp_adc128d818_set("ain7", 1280);
++    qmp_adc128d818_set("temperature", 50000);
++    g_test_message("Injected ain7 = 1280 mV, temperature = 50000 mC");
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 7u);
++    g_test_message("Read ch7 (mode 1): raw 0x%04x -> %u mV", reading,
++             (reading >> 4u) * INTERNAL_VREF_MV / 4096u);
++    g_assert_cmphex(reading, ==, 0x8000);
++}
++
++/* Mode 2 - 4 pseudo-differential pairs */
++static void test_mode2_diff(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_ADV_CONFIG, ADV_CONFIG_MODE_2);
++    g_test_message("Set mode 2 (4 pseudo-differential pairs)");
++
++    qmp_adc128d818_set("ain0", 2000);
++    qmp_adc128d818_set("ain1", 720);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Pair 0 (IN0-IN1): raw 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    qmp_adc128d818_set("ain3", 1920);
++    qmp_adc128d818_set("ain2", 640);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 1u);
++    g_test_message("Pair 1 (IN3-IN2): raw 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    qmp_adc128d818_set("ain4", 1500);
++    qmp_adc128d818_set("ain5", 220);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 2u);
++    g_test_message("Pair 2 (IN4-IN5): raw 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    qmp_adc128d818_set("ain7", 2560);
++    qmp_adc128d818_set("ain6", 1280);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 3u);
++    g_test_message("Pair 3 (IN7-IN6): raw 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 4u);
++    g_test_message("Reserved ch4: raw 0x%04x (expect 0x0000)", reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++
++    qmp_adc128d818_set("ain0", 500);
++    qmp_adc128d818_set("ain1", 1000);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Pair 0 negative dV: raw 0x%04x (expect 0x0000)", reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++}
++
++/* Mode 3 - 4 single-ended + 2 pseudo-differential pairs */
++static void test_mode3_mixed(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_ADV_CONFIG, ADV_CONFIG_MODE_3);
++    g_test_message("Set mode 3 (4 single-ended + 2 differential)");
++
++    qmp_adc128d818_set("ain0", 1280);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Ch0 single-ended: raw 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    qmp_adc128d818_set("ain4", 1500);
++    qmp_adc128d818_set("ain5", 220);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 4u);
++    g_test_message("Ch4 diff (IN4-IN5): raw 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    qmp_adc128d818_set("ain7", 2560);
++    qmp_adc128d818_set("ain6", 1280);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 5u);
++    g_test_message("Ch5 diff (IN7-IN6): raw 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 6u);
++    g_test_message("Reserved ch6: raw 0x%04x (expect 0x0000)", reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++
++    qmp_adc128d818_set("temperature", 25000);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 7u);
++    g_test_message("Ch7 temperature: raw 0x%04x (expect 0x1900)", reading);
++    g_assert_cmphex(reading, ==, 0x1900);
++}
++
++/* Mode change resets channel readings and interrupt status */
++static void test_mode_change_reset(void *obj, void *data,
++                                   QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++    uint8_t status;
++
++    qmp_adc128d818_set("ain0", 1280);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Before mode change, ch0: raw 0x%04x", reading);
++    g_assert_cmphex(reading, !=, 0x0000);
++
++    i2c_set8(dev, REG_CONFIG, 0x00);
++    i2c_set8(dev, REG_LIMIT_BASE, 0x10);
++    qmp_adc128d818_set("ain0", 2560);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    i2c_set8(dev, REG_CONFIG, 0x00);
++    i2c_set8(dev, REG_ADV_CONFIG, ADV_CONFIG_MODE_2);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("After mode change, ch0: raw 0x%04x (expect 0x0000)",
++                   reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++
++    status = i2c_get8(dev, REG_INT_STATUS);
++    g_test_message("After mode change, INT_STATUS: 0x%02x (expect 0x00)",
++                   status);
++    g_assert_cmphex(status, ==, 0x00);
++
++    g_assert_cmphex(i2c_get8(dev, REG_LIMIT_BASE), ==, 0x10);
++    g_test_message("Limit register preserved after mode change");
++}
++
++/* QOM property changes trigger correct differential conversion */
++static void test_diff_qom_trigger(void *obj, void *data,
++                                  QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++    i2c_set8(dev, REG_ADV_CONFIG, ADV_CONFIG_MODE_2);
++
++    qmp_adc128d818_set("ain0", 0);
++    qmp_adc128d818_set("ain1", 0);
++    qmp_adc128d818_set("ain2", 0);
++    qmp_adc128d818_set("ain3", 0);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    qmp_adc128d818_set("ain0", 2000);
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("After ain0=2000, ain1=0: pair0 = 0x%04x (expect 0xC800)",
++             reading);
++    g_assert_cmphex(reading, ==, 0xC800);
++
++    qmp_adc128d818_set("ain1", 720);
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("After ain1=720: pair0 = 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    qmp_adc128d818_set("ain3", 1920);
++    qmp_adc128d818_set("ain2", 640);
++    reading = i2c_get16(dev, REG_CH_READING_BASE + 1u);
++    g_test_message("Pair 1 (IN3-IN2) via QOM: 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++}
++
++/* One-shot conversion works in deep shutdown */
++static void test_deep_shutdown(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++
++    qmp_adc128d818_set("ain0", 1280);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    i2c_set8(dev, REG_DEEP_SHUTDOWN, 0x01);
++    g_test_message("DEEP_SHUTDOWN write while running rejected");
++    g_assert_cmphex(i2c_get8(dev, REG_DEEP_SHUTDOWN), ==, 0x00);
++
++    i2c_set8(dev, REG_CONFIG, 0x00);
++    i2c_set8(dev, REG_DEEP_SHUTDOWN, 0x01);
++    qmp_adc128d818_set("ain0", 0);
++
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Deep shutdown, no one-shot: raw 0x%04x (expect 0x8000)",
++                   reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++
++    i2c_set8(dev, REG_ONE_SHOT, 0x01);
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("Deep shutdown one-shot: raw 0x%04x (expect 0x0000)",
++                   reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++
++    g_assert_cmphex(i2c_get8(dev, REG_DEEP_SHUTDOWN), ==, 0x01);
++
++    i2c_set8(dev, REG_DEEP_SHUTDOWN, 0x00);
++    qmp_adc128d818_set("ain0", 1280);
++    i2c_set8(dev, REG_ONE_SHOT, 0x01);
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("After exit shutdown: raw 0x%04x (expect 0x8000)", reading);
++    g_assert_cmphex(reading, ==, 0x8000);
++}
++
++/* BUSY_STATUS NOT_READY clears after first conversion */
++static void test_busy_status(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++
++    g_assert_cmphex(i2c_get8(dev, REG_BUSY_STATUS) & 0x02, ==, 0x02);
++    g_test_message("After reset: BUSY_STATUS = 0x%02x (NOT_READY set)",
++             i2c_get8(dev, REG_BUSY_STATUS));
++
++    qmp_adc128d818_set("ain0", 0);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++
++    g_assert_cmphex(i2c_get8(dev, REG_BUSY_STATUS) & 0x02, ==, 0x00);
++    g_test_message("After conversion: BUSY_STATUS = 0x%02x (NOT_READY cleared)",
++             i2c_get8(dev, REG_BUSY_STATUS));
++}
++
++/* Programming Channel Disable resets channel readings */
++static void test_chan_disable_clears(void *obj, void *data,
++                                     QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++
++    qmp_adc128d818_set("ain0", 1280);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++    g_assert_cmphex(i2c_get16(dev, REG_CH_READING_BASE), ==, 0x8000);
++
++    i2c_set8(dev, REG_CONFIG, 0x00);
++    i2c_set8(dev, REG_CH_DISABLE, 0x02);
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("After CH_DISABLE write: ch0 raw 0x%04x (expect 0x0000)",
++                   reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++}
++
++/* Programming Advanced Configuration always resets channel readings */
++static void test_adv_config_clears(void *obj, void *data,
++                                   QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint16_t reading;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++
++    qmp_adc128d818_set("ain0", 1280);
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++    g_assert_cmphex(i2c_get16(dev, REG_CH_READING_BASE), ==, 0x8000);
++
++    i2c_set8(dev, REG_CONFIG, 0x00);
++    i2c_set8(dev, REG_ADV_CONFIG, 0x00);
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("After same-mode ADV_CONFIG: ch0 0x%04x (expect 0x0000)",
++                   reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++    g_assert_cmphex(i2c_get16(dev, REG_CH_READING_BASE), ==, 0x8000);
++    i2c_set8(dev, REG_CONFIG, 0x00);
++    qmp_adc128d818_set("ext-vref-mv", 4096);
++    i2c_set8(dev, REG_ADV_CONFIG, ADV_CONFIG_EXT_REF_EN);
++    reading = i2c_get16(dev, REG_CH_READING_BASE);
++    g_test_message("After ext-vref toggle: ch0 0x%04x (expect 0x0000)",
++                   reading);
++    g_assert_cmphex(reading, ==, 0x0000);
++}
++
++/* Conversion Rate register may only be programmed while in shutdown */
++static void test_conv_rate(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_INITIALIZATION);
++
++    i2c_set8(dev, REG_CONV_RATE, 0x01);
++    g_assert_cmphex(i2c_get8(dev, REG_CONV_RATE), ==, 0x01);
++
++    i2c_set8(dev, REG_CONFIG, CONFIG_START);
++    i2c_set8(dev, REG_CONV_RATE, 0x00);
++    g_test_message("CONV_RATE while running: 0x%02x (expect unchanged 0x01)",
++             i2c_get8(dev, REG_CONV_RATE));
++    g_assert_cmphex(i2c_get8(dev, REG_CONV_RATE), ==, 0x01);
++}
++
+ static void adc128d818_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -475,5 +837,20 @@ static void adc128d818_register_nodes(void)
+     qos_add_test("int-clear", "adc128d818", test_int_clear, NULL);
+     qos_add_test("low-limit", "adc128d818", test_low_limit, NULL);
+     qos_add_test("temp-hysteresis", "adc128d818", test_temp_hysteresis, NULL);
++    qos_add_test("channel-disable", "adc128d818", test_channel_disable, NULL);
++    qos_add_test("one-shot", "adc128d818", test_one_shot, NULL);
++    qos_add_test("mode-selection", "adc128d818", test_mode_selection, NULL);
++    qos_add_test("mode2-diff", "adc128d818", test_mode2_diff, NULL);
++    qos_add_test("mode3-mixed", "adc128d818", test_mode3_mixed, NULL);
++    qos_add_test("mode-change-reset", "adc128d818", test_mode_change_reset,
++                 NULL);
++    qos_add_test("diff-qom-trigger", "adc128d818", test_diff_qom_trigger, NULL);
++    qos_add_test("deep-shutdown", "adc128d818", test_deep_shutdown, NULL);
++    qos_add_test("busy-status", "adc128d818", test_busy_status, NULL);
++    qos_add_test("chan-disable-clears", "adc128d818", test_chan_disable_clears,
++                 NULL);
++    qos_add_test("adv-config-clears", "adc128d818", test_adv_config_clears,
++                 NULL);
++    qos_add_test("conv-rate", "adc128d818", test_conv_rate, NULL);
+ }
+ libqos_init(adc128d818_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0606-hw-arm-aspeed-anacapa-use-ASCII-in-comments.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0606-hw-arm-aspeed-anacapa-use-ASCII-in-comments.patch
@@ -1,0 +1,62 @@
+From 588941c7db4d1004fc0239f842f62ec950336bb5 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Tue, 7 Jul 2026 11:16:00 +0200
+Subject: [PATCH 606/631] hw/arm/aspeed: anacapa: use ASCII in comments
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The anacapa machine source contains a few comments using the U+2014 EM
+DASH character. Replace them with plain ASCII hyphens so the file stays
+ASCII-only.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Link: https://lore.kernel.org/qemu-devel/20260707091609.97759-8-emmanuel.blot@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/arm/aspeed_ast2600_anacapa.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/hw/arm/aspeed_ast2600_anacapa.c b/hw/arm/aspeed_ast2600_anacapa.c
+index a1c8111a934..bd6cc006860 100644
+--- a/hw/arm/aspeed_ast2600_anacapa.c
++++ b/hw/arm/aspeed_ast2600_anacapa.c
+@@ -242,7 +242,7 @@ static void anacapa_bmc_i2c_init(AspeedMachineState *bmc)
+     /* &i2c1 */
+     /* eeprom@50 */
+     at24c_eeprom_init(i2c[1], 0x50, 256 * KiB);
+-    /* i2c-mux@70 (PCA9546) — 4 channels, empty */
++    /* i2c-mux@70 (PCA9546) - 4 channels, empty */
+     i2c_slave_create_simple(i2c[1], TYPE_PCA9546, 0x70);
+ 
+     /* &i2c4 */
+@@ -259,7 +259,7 @@ static void anacapa_bmc_i2c_init(AspeedMachineState *bmc)
+     i2c_mux = i2c_slave_create_simple(i2c[8], TYPE_PCA9546, 0x72);
+ 
+     /* i2c8mux ch0 */
+-    /* adc128d818@1f — no model */
++    /* adc128d818@1f - no model */
+     /* pca9555@22 */
+     i2c_slave_create_simple(pca954x_i2c_get_bus(i2c_mux, 0),
+                             TYPE_PCA9552, 0x22);
+@@ -305,7 +305,7 @@ static void anacapa_bmc_i2c_init(AspeedMachineState *bmc)
+     /* i2c-mux@71 (PCA9548) */
+     i2c_mux = i2c_slave_create_simple(i2c[11], TYPE_PCA9548, 0x71);
+ 
+-    /* i2c11mux ch0-ch4 — empty */
++    /* i2c11mux ch0-ch4 - empty */
+ 
+     /* i2c11mux ch5 */
+     /* pca9555@22 */
+@@ -328,7 +328,7 @@ static void anacapa_bmc_i2c_init(AspeedMachineState *bmc)
+                           hpm_brd_id_eeprom, hpm_brd_id_eeprom_len);
+ 
+     /* i2c13mux ch7 */
+-    /* nfc@28 — no model */
++    /* nfc@28 - no model */
+ }
+ 
+ static void aspeed_machine_anacapa_class_init(ObjectClass *oc,
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0607-hw-gpio-pca9552-register-types-with-DEFINE_TYPES.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0607-hw-gpio-pca9552-register-types-with-DEFINE_TYPES.patch
@@ -1,0 +1,91 @@
+From d7b944a145cd49d620545a2aa7089260fafc8b2d Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:39 +0200
+Subject: [PATCH 607/631] hw/gpio: pca9552: register types with DEFINE_TYPES()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Replace the separate TypeInfo definitions and pca955x_register_types()
+registration function with a single type array registered through the
+DEFINE_TYPES() macro, to prepare addition of new PCA955x-derived devices.
+
+No functional change.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-1-814575bc076b@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9552.c | 49 ++++++++++++++++++++---------------------------
+ 1 file changed, 21 insertions(+), 28 deletions(-)
+
+diff --git a/hw/gpio/pca9552.c b/hw/gpio/pca9552.c
+index b13ac9fd9ce..50e868a6e9a 100644
+--- a/hw/gpio/pca9552.c
++++ b/hw/gpio/pca9552.c
+@@ -492,16 +492,6 @@ static void pca955x_class_init(ObjectClass *klass, const void *data)
+     device_class_set_props(dc, pca955x_properties);
+ }
+ 
+-static const TypeInfo pca955x_info = {
+-    .name          = TYPE_PCA955X,
+-    .parent        = TYPE_I2C_SLAVE,
+-    .instance_init = pca955x_initfn,
+-    .instance_size = sizeof(PCA955xState),
+-    .class_init    = pca955x_class_init,
+-    .class_size    = sizeof(PCA955xClass),
+-    .abstract      = true,
+-};
+-
+ static void pca9552_class_init(ObjectClass *oc, const void *data)
+ {
+     DeviceClass *dc = DEVICE_CLASS(oc);
+@@ -526,23 +516,26 @@ static void pca9535_class_init(ObjectClass *oc, const void *data)
+     pc->has_led_support = false;
+ }
+ 
+-static const TypeInfo pca9552_info = {
+-    .name          = TYPE_PCA9552,
+-    .parent        = TYPE_PCA955X,
+-    .class_init    = pca9552_class_init,
++static const TypeInfo pca955x_types[] = {
++    {
++        .name          = TYPE_PCA955X,
++        .parent        = TYPE_I2C_SLAVE,
++        .instance_init = pca955x_initfn,
++        .instance_size = sizeof(PCA955xState),
++        .class_init    = pca955x_class_init,
++        .class_size    = sizeof(PCA955xClass),
++        .abstract      = true,
++    },
++    {
++        .name          = TYPE_PCA9552,
++        .parent        = TYPE_PCA955X,
++        .class_init    = pca9552_class_init,
++    },
++    {
++        .name          = TYPE_PCA9535,
++        .parent        = TYPE_PCA955X,
++        .class_init    = pca9535_class_init,
++    }
+ };
+ 
+-static const TypeInfo pca9535_info = {
+-    .name          = TYPE_PCA9535,
+-    .parent        = TYPE_PCA955X,
+-    .class_init    = pca9535_class_init,
+-};
+-
+-static void pca955x_register_types(void)
+-{
+-    type_register_static(&pca955x_info);
+-    type_register_static(&pca9552_info);
+-    type_register_static(&pca9535_info);
+-}
+-
+-type_init(pca955x_register_types)
++DEFINE_TYPES(pca955x_types)
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0608-hw-gpio-pca9552-move-PCA955xState-definition-out-of-.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0608-hw-gpio-pca9552-move-PCA955xState-definition-out-of-.patch
@@ -1,0 +1,143 @@
+From 14dccb72e3a07064dacf4aed5ff21eead0504f11 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:40 +0200
+Subject: [PATCH 608/631] hw/gpio: pca9552: move PCA955xState definition out of
+ the header
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Nothing outside pca9552.c uses the PCA955xState structure, its instance
+checker, or the PCA955X_NR_REGS/PCA955X_PIN_COUNT_MAX defines: the board
+files and qtests only rely on the TYPE_* name macros (and the register
+macros in pca9552_regs.h).
+
+Move the state structure and the size defines into pca9552.c, leaving
+pca9552.h with just the type-name macros. While at it, replace the
+separate DECLARE_INSTANCE_CHECKER and DECLARE_CLASS_CHECKERS declarations
+with a single OBJECT_DECLARE_TYPE().
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-2-814575bc076b@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9552.c         | 29 ++++++++++++++++++++++++-----
+ include/hw/gpio/pca9552.h | 30 ++++--------------------------
+ 2 files changed, 28 insertions(+), 31 deletions(-)
+
+diff --git a/hw/gpio/pca9552.c b/hw/gpio/pca9552.c
+index 50e868a6e9a..36bc4f86edb 100644
+--- a/hw/gpio/pca9552.c
++++ b/hw/gpio/pca9552.c
+@@ -1,7 +1,10 @@
+ /*
+- * PCA9552 I2C LED blinker
++ * PCA955X I2C LED blinker and I/O expanders
+  *
+  *     https://www.nxp.com/docs/en/application-note/AN264.pdf
++ *     https://www.nxp.com/docs/en/data-sheet/PCA9552.pdf
++ *     https://www.nxp.com/docs/en/data-sheet/PCA9555.pdf
++ *     https://www.nxp.com/docs/en/data-sheet/PCA9535_PCA9535C.pdf
+  *
+  * Copyright (c) 2017-2018, IBM Corporation.
+  * Copyright (c) 2020 Philippe Mathieu-Daudé
+@@ -12,9 +15,9 @@
+ 
+ #include "qemu/osdep.h"
+ #include "qemu/log.h"
+-#include "qemu/module.h"
+ #include "qemu/bitops.h"
+ #include "hw/core/qdev-properties.h"
++#include "hw/i2c/i2c.h"
+ #include "hw/gpio/pca9552.h"
+ #include "hw/gpio/pca9552_regs.h"
+ #include "hw/core/irq.h"
+@@ -24,6 +27,25 @@
+ #include "trace.h"
+ #include "qom/object.h"
+ 
++#define PCA955X_NR_REGS 10
++#define PCA955X_PIN_COUNT_MAX 16
++
++OBJECT_DECLARE_TYPE(PCA955xState, PCA955xClass, PCA955X)
++
++struct PCA955xState {
++    /*< private >*/
++    I2CSlave i2c;
++    /*< public >*/
++
++    uint8_t len;
++    uint8_t pointer;
++
++    uint8_t regs[PCA955X_NR_REGS];
++    qemu_irq gpio_out[PCA955X_PIN_COUNT_MAX];
++    uint8_t ext_state[PCA955X_PIN_COUNT_MAX];
++    char *description; /* For debugging purpose only */
++};
++
+ struct PCA955xClass {
+     /*< private >*/
+     I2CSlaveClass parent_class;
+@@ -33,10 +55,7 @@ struct PCA955xClass {
+     uint8_t max_reg;
+     bool has_led_support;
+ };
+-typedef struct PCA955xClass PCA955xClass;
+ 
+-DECLARE_CLASS_CHECKERS(PCA955xClass, PCA955X,
+-                       TYPE_PCA955X)
+ /*
+  * Note:  The LED_ON and LED_OFF configuration values for the PCA955X
+  *        chips are the reverse of the PCA953X family of chips.
+diff --git a/include/hw/gpio/pca9552.h b/include/hw/gpio/pca9552.h
+index 43b175235d2..71479ea0006 100644
+--- a/include/hw/gpio/pca9552.h
++++ b/include/hw/gpio/pca9552.h
+@@ -1,39 +1,17 @@
+ /*
+- * PCA9552 I2C LED blinker
++ * PCA955X I2C LED blinker and I/O expanders
+  *
+  * Copyright (c) 2017-2018, IBM Corporation.
+  *
+  * This work is licensed under the terms of the GNU GPL, version 2 or
+  * later. See the COPYING file in the top-level directory.
+  */
+-#ifndef PCA9552_H
+-#define PCA9552_H
+ 
+-#include "hw/i2c/i2c.h"
+-#include "qom/object.h"
++#ifndef HW_GPIO_PCA9552_H
++#define HW_GPIO_PCA9552_H
+ 
+-#define TYPE_PCA9552 "pca9552"
+ #define TYPE_PCA955X "pca955x"
++#define TYPE_PCA9552 "pca9552"
+ #define TYPE_PCA9535 "pca9535"
+-typedef struct PCA955xState PCA955xState;
+-DECLARE_INSTANCE_CHECKER(PCA955xState, PCA955X,
+-                         TYPE_PCA955X)
+-
+-#define PCA955X_NR_REGS 10
+-#define PCA955X_PIN_COUNT_MAX 16
+-
+-struct PCA955xState {
+-    /*< private >*/
+-    I2CSlave i2c;
+-    /*< public >*/
+-
+-    uint8_t len;
+-    uint8_t pointer;
+-
+-    uint8_t regs[PCA955X_NR_REGS];
+-    qemu_irq gpio_out[PCA955X_PIN_COUNT_MAX];
+-    uint8_t ext_state[PCA955X_PIN_COUNT_MAX];
+-    char *description; /* For debugging purpose only */
+-};
+ 
+ #endif
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0609-hw-gpio-pca9552-rename-I2CSlave-member-to-parent_obj.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0609-hw-gpio-pca9552-rename-I2CSlave-member-to-parent_obj.patch
@@ -1,0 +1,44 @@
+From ab006d6cf676b66236d3e69b9ab3a4a237b94329 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:41 +0200
+Subject: [PATCH 609/631] hw/gpio: pca9552: rename I2CSlave member to
+ parent_obj
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Use the conventional parent_obj name for the embedded I2CSlave instance.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Signed-off-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-3-814575bc076b@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9552.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/hw/gpio/pca9552.c b/hw/gpio/pca9552.c
+index 36bc4f86edb..da21e56aabd 100644
+--- a/hw/gpio/pca9552.c
++++ b/hw/gpio/pca9552.c
+@@ -34,7 +34,7 @@ OBJECT_DECLARE_TYPE(PCA955xState, PCA955xClass, PCA955X)
+ 
+ struct PCA955xState {
+     /*< private >*/
+-    I2CSlave i2c;
++    I2CSlave parent_obj;
+     /*< public >*/
+ 
+     uint8_t len;
+@@ -401,7 +401,7 @@ static const VMStateDescription pca9552_vmstate = {
+         VMSTATE_UINT8(pointer, PCA955xState),
+         VMSTATE_UINT8_ARRAY(regs, PCA955xState, PCA955X_NR_REGS),
+         VMSTATE_UINT8_ARRAY(ext_state, PCA955xState, PCA955X_PIN_COUNT_MAX),
+-        VMSTATE_I2C_SLAVE(i2c, PCA955xState),
++        VMSTATE_I2C_SLAVE(parent_obj, PCA955xState),
+         VMSTATE_END_OF_LIST()
+     }
+ };
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0610-hw-gpio-pca9552-default-description-to-the-instantia.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0610-hw-gpio-pca9552-default-description-to-the-instantia.patch
@@ -1,0 +1,38 @@
+From 75f02fa098c0a38c48751a28aa6a7eddc6dc1cbc Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:42 +0200
+Subject: [PATCH 610/631] hw/gpio: pca9552: default description to the
+ instantiated type name
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When no description is supplied, fall back to the actual QOM type name
+(pca9552 / pca9535 / pca9555) via object_get_typename() instead of the
+opaque "pca-unspecified" placeholder, matching the PCA9554 model and
+giving meaningful device labels in traces.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-4-814575bc076b@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9552.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hw/gpio/pca9552.c b/hw/gpio/pca9552.c
+index da21e56aabd..ffeb438d2ab 100644
+--- a/hw/gpio/pca9552.c
++++ b/hw/gpio/pca9552.c
+@@ -488,7 +488,7 @@ static void pca955x_realize(DeviceState *dev, Error **errp)
+     PCA955xState *s = PCA955X(dev);
+ 
+     if (!s->description) {
+-        s->description = g_strdup("pca-unspecified");
++        s->description = g_strdup(object_get_typename(OBJECT(dev)));
+     }
+ 
+     qdev_init_gpio_out(dev, s->gpio_out, k->pin_count);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0611-hw-gpio-pca9552-declare-pca9555-device-as-an-alias-o.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0611-hw-gpio-pca9552-declare-pca9555-device-as-an-alias-o.patch
@@ -1,0 +1,65 @@
+From 6c383115c6784026fa521c736f2d706e0b61f656 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:43 +0200
+Subject: [PATCH 611/631] hw/gpio: pca9552: declare pca9555 device as an alias
+ of pca9535 device
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+PCA9555 HW is mostly identical to PCA9535.
+PCA9555 HW features pull-up resistors that are not available on PCA9535.
+
+Pull-up are not handled by current PCA955x implementation and PCA9535
+already initializes input as Hi-Z.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-5-814575bc076b@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9552.c         | 9 +++++++--
+ include/hw/gpio/pca9552.h | 1 +
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/hw/gpio/pca9552.c b/hw/gpio/pca9552.c
+index ffeb438d2ab..3b9b63eb176 100644
+--- a/hw/gpio/pca9552.c
++++ b/hw/gpio/pca9552.c
+@@ -523,7 +523,7 @@ static void pca9552_class_init(ObjectClass *oc, const void *data)
+     pc->has_led_support = true;
+ }
+ 
+-static void pca9535_class_init(ObjectClass *oc, const void *data)
++static void pca95x5_class_init(ObjectClass *oc, const void *data)
+ {
+     DeviceClass *dc = DEVICE_CLASS(oc);
+     PCA955xClass *pc = PCA955X_CLASS(oc);
+@@ -553,7 +553,12 @@ static const TypeInfo pca955x_types[] = {
+     {
+         .name          = TYPE_PCA9535,
+         .parent        = TYPE_PCA955X,
+-        .class_init    = pca9535_class_init,
++        .class_init    = pca95x5_class_init,
++    },
++    {
++        .name          = TYPE_PCA9555,
++        .parent        = TYPE_PCA955X,
++        .class_init    = pca95x5_class_init,
+     }
+ };
+ 
+diff --git a/include/hw/gpio/pca9552.h b/include/hw/gpio/pca9552.h
+index 71479ea0006..5299c13829b 100644
+--- a/include/hw/gpio/pca9552.h
++++ b/include/hw/gpio/pca9552.h
+@@ -13,5 +13,6 @@
+ #define TYPE_PCA955X "pca955x"
+ #define TYPE_PCA9552 "pca9552"
+ #define TYPE_PCA9535 "pca9535"
++#define TYPE_PCA9555 "pca9555"
+ 
+ #endif
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0612-hw-gpio-pca9552-use-the-Resettable-interface-instead.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0612-hw-gpio-pca9552-use-the-Resettable-interface-instead.patch
@@ -1,0 +1,79 @@
+From 2d505427f7c14f4fc8dc0ac4cb9601b5bcac0e5c Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:44 +0200
+Subject: [PATCH 612/631] hw/gpio: pca9552: use the Resettable interface
+ instead of legacy reset
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Convert the PCA9552 and PCA9535/PCA9555 reset handlers from the legacy
+device reset hook to the Resettable interface: move each reset body into
+a ResettableHoldPhase handler and register it through the class's
+ResettableClass::phases.hold instead of device_class_set_legacy_reset().
+
+No functional change.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-6-814575bc076b@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9552.c | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/hw/gpio/pca9552.c b/hw/gpio/pca9552.c
+index 3b9b63eb176..66f699bf6a0 100644
+--- a/hw/gpio/pca9552.c
++++ b/hw/gpio/pca9552.c
+@@ -406,9 +406,9 @@ static const VMStateDescription pca9552_vmstate = {
+     }
+ };
+ 
+-static void pca9552_reset(DeviceState *dev)
++static void pca9552_reset_hold(Object *obj, ResetType type)
+ {
+-    PCA955xState *s = PCA955X(dev);
++    PCA955xState *s = PCA955X(obj);
+ 
+     s->regs[PCA9552_PSC0] = 0xFF;
+     s->regs[PCA9552_PWM0] = 0x80;
+@@ -426,9 +426,9 @@ static void pca9552_reset(DeviceState *dev)
+     s->len = 0;
+ }
+ 
+-static void pca9535_reset(DeviceState *dev)
++static void pca9535_reset_hold(Object *obj, ResetType type)
+ {
+-    PCA955xState *s = PCA955X(dev);
++    PCA955xState *s = PCA955X(obj);
+ 
+     s->regs[PCA9535_INPUT0] = 0xFF;   /* All inputs high (pull-ups) */
+     s->regs[PCA9535_INPUT1] = 0xFF;   /* All inputs high (pull-ups) */
+@@ -514,9 +514,10 @@ static void pca955x_class_init(ObjectClass *klass, const void *data)
+ static void pca9552_class_init(ObjectClass *oc, const void *data)
+ {
+     DeviceClass *dc = DEVICE_CLASS(oc);
++    ResettableClass *rc = RESETTABLE_CLASS(oc);
+     PCA955xClass *pc = PCA955X_CLASS(oc);
+ 
+-    device_class_set_legacy_reset(dc, pca9552_reset);
++    rc->phases.hold = pca9552_reset_hold;
+     dc->vmsd = &pca9552_vmstate;
+     pc->max_reg = PCA9552_LS3;
+     pc->pin_count = 16;
+@@ -526,9 +527,10 @@ static void pca9552_class_init(ObjectClass *oc, const void *data)
+ static void pca95x5_class_init(ObjectClass *oc, const void *data)
+ {
+     DeviceClass *dc = DEVICE_CLASS(oc);
++    ResettableClass *rc = RESETTABLE_CLASS(oc);
+     PCA955xClass *pc = PCA955X_CLASS(oc);
+ 
+-    device_class_set_legacy_reset(dc, pca9535_reset);
++    rc->phases.hold = pca9535_reset_hold;
+     dc->vmsd = &pca9552_vmstate;
+     pc->max_reg = PCA9535_CONFIG1;
+     pc->pin_count = 16;
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0613-hw-gpio-pca9552-apply-input-polarity-inversion-on-re.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0613-hw-gpio-pca9552-apply-input-polarity-inversion-on-re.patch
@@ -1,0 +1,81 @@
+From b453bb2a289775e075538c0ae5ea7c0e7c7d43e4 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:45 +0200
+Subject: [PATCH 613/631] hw/gpio: pca9552: apply input polarity inversion on
+ read
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The PCA9535 polarity inversion register inverts the value read back from
+the input port for every pin, regardless of its direction, and does not
+affect the output drive or the physical pin level.
+
+Store the raw pin level in the input register and apply the polarity
+inversion when the input port is read, instead of XORing it into the
+stored value of output-configured pins only. The interrupt output now
+reflects the raw pin level, matching the datasheet.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-7-814575bc076b@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9552.c | 25 ++++++++++++++++++-------
+ 1 file changed, 18 insertions(+), 7 deletions(-)
+
+diff --git a/hw/gpio/pca9552.c b/hw/gpio/pca9552.c
+index 66f699bf6a0..24f64654158 100644
+--- a/hw/gpio/pca9552.c
++++ b/hw/gpio/pca9552.c
+@@ -167,9 +167,12 @@ static void pca955x_update_pin_input(PCA955xState *s)
+             /* PCA9535: Simple GPIO behavior */
+             uint8_t config_reg = PCA9535_CONFIG0 + (i / 8);
+             uint8_t output_reg = PCA9535_OUTPUT0 + (i / 8);
+-            uint8_t polarity_reg = PCA9535_POLARITY0 + (i / 8);
+ 
+-            /* Check if pin is configured as input */
++            /*
++             * The input register holds the raw pin logic level; the
++             * polarity inversion register is only applied when the input
++             * port is read (see pca955x_read()).
++             */
+             if (s->regs[config_reg] & bit_mask) {
+                 /* Input mode - reflect external state */
+                 if (s->ext_state[i] == PCA9552_PIN_LOW) {
+@@ -179,12 +182,8 @@ static void pca955x_update_pin_input(PCA955xState *s)
+                 }
+             } else {
+                 /* Output mode - reflect output register value */
+-                uint8_t output_bit = s->regs[output_reg] & bit_mask;
+-                uint8_t polarity_bit = s->regs[polarity_reg] & bit_mask;
+-
+-                /* Apply polarity inversion if set */
+                 s->regs[input_reg] = (s->regs[input_reg] & ~bit_mask) |
+-                                    ((output_bit ^ polarity_bit) & bit_mask);
++                                     (s->regs[output_reg] & bit_mask);
+             }
+         }
+ 
+@@ -206,6 +205,18 @@ static uint8_t pca955x_read(PCA955xState *s, uint8_t reg)
+         return 0xFF;
+     }
+ 
++    /*
++     * On the GPIO variants, reading an input port returns the raw pin
++     * levels XORed with the polarity inversion register, as specified by
++     * the datasheet.
++     */
++    if (!k->has_led_support &&
++        (reg == PCA9535_INPUT0 || reg == PCA9535_INPUT1)) {
++        uint8_t polarity_reg = PCA9535_POLARITY0 + (reg - PCA9535_INPUT0);
++
++        return s->regs[reg] ^ s->regs[polarity_reg];
++    }
++
+     return s->regs[reg];
+ }
+ 
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0614-hw-gpio-pca9552-conform-GPIO-command-handling-to-the.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0614-hw-gpio-pca9552-conform-GPIO-command-handling-to-the.patch
@@ -1,0 +1,114 @@
+From ef402aa7d0bbeb767828e0c3505a73315ec7322b Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:46 +0200
+Subject: [PATCH 614/631] hw/gpio: pca9552: conform GPIO command handling to
+ the datasheet
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The PCA9535/PCA9555 GPIO expanders share the PCA955X command dispatch
+path with the PCA9552 LED blinker, but their register access differs from
+the LED variant:
+
+  - Auto-increment happens on every access and toggles bit 0 so the
+    pointer stays within the addressed register pair (input, output,
+    polarity, config); there is no AI enable bit.
+
+  - The command byte only decodes 3 bits, so addresses beyond the last
+    register alias back into the 8-register window instead of faulting.
+
+Branch the auto-increment and command-decode logic on has_led_support so
+the GPIO variants follow their datasheet while the PCA9552 behaviour is
+left untouched.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-8-814575bc076b@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9552.c | 37 +++++++++++++++++++++++++++++++------
+ 1 file changed, 31 insertions(+), 6 deletions(-)
+
+diff --git a/hw/gpio/pca9552.c b/hw/gpio/pca9552.c
+index 24f64654158..54a5945d925 100644
+--- a/hw/gpio/pca9552.c
++++ b/hw/gpio/pca9552.c
+@@ -259,14 +259,26 @@ static void pca955x_write(PCA955xState *s, uint8_t reg, uint8_t data)
+ }
+ 
+ /*
+- * When Auto-Increment is on, the register address is incremented
+- * after each byte is sent to or received by the device. The index
+- * rollovers to 0 when the maximum register address is reached.
++ * Advance the command pointer after each byte sent to or received from the
++ * device.
++ *
++ * The LED variant auto-increments only when the AI bit (bit 4) is set in the
++ * command byte, rolling over to 0 once the maximum register address is
++ * reached.
++ *
++ * The GPIO variants auto-increment on every access, toggling bit 0 so the
++ * pointer stays within the addressed register pair
++ * (input/output/polarity/config), as specified by their datasheet.
+  */
+ static void pca955x_autoinc(PCA955xState *s)
+ {
+     PCA955xClass *k = PCA955X_GET_CLASS(s);
+ 
++    if (!k->has_led_support) {
++        s->pointer ^= 0x1;
++        return;
++    }
++
+     if (s->pointer != 0xFF && s->pointer & PCA9552_AUTOINC) {
+         uint8_t reg = s->pointer & 0xf;
+ 
+@@ -275,12 +287,25 @@ static void pca955x_autoinc(PCA955xState *s)
+     }
+ }
+ 
++/*
++ * The LED variant addresses its registers with a 4-bit command field, while
++ * the GPIO variants only decode 3 bits (the command wraps into the 8-register
++ * window).
++ */
++static inline uint8_t pca955x_cmd_reg(PCA955xState *s)
++{
++    PCA955xClass *k = PCA955X_GET_CLASS(s);
++
++    return s->pointer & (k->has_led_support ? 0xf : 0x7);
++}
++
+ static uint8_t pca955x_recv(I2CSlave *i2c)
+ {
+     PCA955xState *s = PCA955X(i2c);
++    PCA955xClass *k = PCA955X_GET_CLASS(s);
+     uint8_t ret;
+ 
+-    ret = pca955x_read(s, s->pointer & 0xf);
++    ret = pca955x_read(s, pca955x_cmd_reg(s));
+ 
+     /*
+      * From the Specs:
+@@ -292,7 +317,7 @@ static uint8_t pca955x_recv(I2CSlave *i2c)
+      * I don't know what should be done in this case, so throw an
+      * error.
+      */
+-    if (s->pointer == PCA9552_AUTOINC) {
++    if (k->has_led_support && s->pointer == PCA9552_AUTOINC) {
+         qemu_log_mask(LOG_GUEST_ERROR,
+                       "%s: Autoincrement read starting with register 0\n",
+                       __func__);
+@@ -312,7 +337,7 @@ static int pca955x_send(I2CSlave *i2c, uint8_t data)
+         s->pointer = data;
+         s->len++;
+     } else {
+-        pca955x_write(s, s->pointer & 0xf, data);
++        pca955x_write(s, pca955x_cmd_reg(s), data);
+ 
+         pca955x_autoinc(s);
+     }
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0615-hw-gpio-pca9552-expose-GPIO-pins-as-pin-d-QOM-proper.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0615-hw-gpio-pca9552-expose-GPIO-pins-as-pin-d-QOM-proper.patch
@@ -1,0 +1,155 @@
+From 1692491456996b7bcf69c2820c7ac35798f59df7 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:47 +0200
+Subject: [PATCH 615/631] hw/gpio: pca9552: expose GPIO pins as pin%d QOM
+ properties
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The PCA9552 exposes its LED channels as led%d QOM string properties, but
+the GPIO variants (PCA9535/PCA9555) inherited the same led%d interface,
+which drives the LED selector registers and is meaningless for a plain
+I/O expander.
+
+Add pin%d string properties ("low"/"high") for the GPIO variants,
+mirroring the standalone pca9555 model:
+
+  - reading returns the raw pin logic level from the INPUT register;
+  - writing drives the external input level, but only for pins the guest
+    has configured as inputs (writes to output pins are ignored with a
+    LOG_UNIMP message).
+
+The LED variant keeps its led%d properties.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-9-814575bc076b@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9552.c | 91 ++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 86 insertions(+), 5 deletions(-)
+
+diff --git a/hw/gpio/pca9552.c b/hw/gpio/pca9552.c
+index 54a5945d925..719149b7174 100644
+--- a/hw/gpio/pca9552.c
++++ b/hw/gpio/pca9552.c
+@@ -68,6 +68,7 @@ struct PCA955xClass {
+ #define PCA9552_PIN_HIZ  0x1
+ 
+ static const char *led_state[] = {"on", "off", "pwm0", "pwm1"};
++static const char *pin_state[] = {"low", "high"};
+ 
+ static uint8_t pca955x_pin_get_config(PCA955xState *s, int pin)
+ {
+@@ -428,6 +429,79 @@ static void pca955x_set_led(Object *obj, Visitor *v, const char *name,
+     pca955x_write(s, reg, val);
+ }
+ 
++static void pca955x_set_ext_state(PCA955xState *s, int pin, int level);
++
++static void pca955x_get_pin(Object *obj, Visitor *v, const char *name,
++                            void *opaque, Error **errp)
++{
++    PCA955xClass *k = PCA955X_GET_CLASS(obj);
++    PCA955xState *s = PCA955X(obj);
++    int pin, rc;
++    uint8_t input_reg, state;
++
++    rc = sscanf(name, "pin%2d", &pin);
++    if (rc != 1) {
++        error_setg(errp, "%s: error reading %s", __func__, name);
++        return;
++    }
++    if (pin < 0 || pin >= k->pin_count) {
++        error_setg(errp, "%s invalid pin %s", __func__, name);
++        return;
++    }
++
++    /*
++     * Report the raw pin logic level; polarity inversion is a read-time
++     * transform applied to the INPUT register, not to the pin state itself.
++     */
++    input_reg = PCA9535_INPUT0 + (pin / 8);
++    state = (s->regs[input_reg] >> (pin % 8)) & 0x1;
++    visit_type_str(v, name, (char **)&pin_state[state], errp);
++}
++
++static void pca955x_set_pin(Object *obj, Visitor *v, const char *name,
++                            void *opaque, Error **errp)
++{
++    PCA955xClass *k = PCA955X_GET_CLASS(obj);
++    PCA955xState *s = PCA955X(obj);
++    int pin, rc;
++    uint8_t state, config_reg;
++    g_autofree char *state_str = NULL;
++
++    if (!visit_type_str(v, name, &state_str, errp)) {
++        return;
++    }
++    rc = sscanf(name, "pin%2d", &pin);
++    if (rc != 1) {
++        error_setg(errp, "%s: error reading %s", __func__, name);
++        return;
++    }
++    if (pin < 0 || pin >= k->pin_count) {
++        error_setg(errp, "%s invalid pin %s", __func__, name);
++        return;
++    }
++
++    for (state = 0; state < ARRAY_SIZE(pin_state); state++) {
++        if (!strcmp(state_str, pin_state[state])) {
++            break;
++        }
++    }
++    if (state >= ARRAY_SIZE(pin_state)) {
++        error_setg(errp, "%s invalid pin state %s", __func__, state_str);
++        return;
++    }
++
++    /* Only input-configured pins can be driven by an external device. */
++    config_reg = PCA9535_CONFIG0 + (pin / 8);
++    if (!((s->regs[config_reg] >> (pin % 8)) & 0x1)) {
++        qemu_log_mask(LOG_UNIMP,
++                      "%s: pin %d is configured as output, ignoring set\n",
++                      s->description, pin);
++        return;
++    }
++
++    pca955x_set_ext_state(s, pin, state != PCA9552_PIN_LOW);
++}
++
+ static const VMStateDescription pca9552_vmstate = {
+     .name = "PCA9552",
+     .version_id = 0,
+@@ -485,15 +559,22 @@ static void pca9535_reset_hold(Object *obj, ResetType type)
+ static void pca955x_initfn(Object *obj)
+ {
+     PCA955xClass *k = PCA955X_GET_CLASS(obj);
+-    int led;
+ 
+     assert(k->pin_count <= PCA955X_PIN_COUNT_MAX);
+-    for (led = 0; led < k->pin_count; led++) {
++    for (int ix = 0; ix < k->pin_count; ix++) {
+         char *name;
+ 
+-        name = g_strdup_printf("led%d", led);
+-        object_property_add(obj, name, "bool", pca955x_get_led, pca955x_set_led,
+-                            NULL, NULL);
++        if (k->has_led_support) {
++            /* LED variant: expose the LED selector state as led%d. */
++            name = g_strdup_printf("led%d", ix);
++            object_property_add(obj, name, "bool",
++                                pca955x_get_led, pca955x_set_led, NULL, NULL);
++        } else {
++            /* GPIO variant: expose the pin logic level as pin%d. */
++            name = g_strdup_printf("pin%d", ix);
++            object_property_add(obj, name, "str",
++                                pca955x_get_pin, pca955x_set_pin, NULL, NULL);
++        }
+         g_free(name);
+     }
+ }
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0616-tests-qtest-add-PCA9555-register-access-tests.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0616-tests-qtest-add-PCA9555-register-access-tests.patch
@@ -1,0 +1,88 @@
+From 2c648c011652f0b3db0aa888a48919001ace9fc3 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:48 +0200
+Subject: [PATCH 616/631] tests/qtest: add PCA9555 register access tests
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Introduce a qtest for the PCA9555 16-bit I/O port expander.
+
+This first set covers the power-on reset defaults and the read/write
+behaviour of the OUTPUT, CONFIG and POLARITY register pairs.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-10-814575bc076b@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/meson.build    |  1 +
+ tests/qtest/pca9555-test.c | 44 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 45 insertions(+)
+ create mode 100644 tests/qtest/pca9555-test.c
+
+diff --git a/tests/qtest/meson.build b/tests/qtest/meson.build
+index 5e1fc597e6d..e92130bd04d 100644
+--- a/tests/qtest/meson.build
++++ b/tests/qtest/meson.build
+@@ -319,6 +319,7 @@ qos_test_ss.add(
+   'tulip-test.c',
+   'nvme-test.c',
+   'pca9552-test.c',
++  'pca9555-test.c',
+   'pci-test.c',
+   'pcnet-test.c',
+   'rs5c372-test.c',
+diff --git a/tests/qtest/pca9555-test.c b/tests/qtest/pca9555-test.c
+new file mode 100644
+index 00000000000..5945c3441e9
+--- /dev/null
++++ b/tests/qtest/pca9555-test.c
+@@ -0,0 +1,44 @@
++/*
++ * QTest testcase for the PCA9555 16-bit I/O port expander
++ *
++ * Copyright (c) Meta Platforms, Inc. and affiliates.
++ *
++ * SPDX-License-Identifier: GPL-2.0-or-later
++ */
++
++#include "qemu/osdep.h"
++#include "hw/gpio/pca9552_regs.h"
++#include "libqos/i2c.h"
++#include "libqos/qgraph.h"
++
++#define PCA9555_TEST_ADDR 0x20
++
++/* Verify power-on reset defaults match the PCA9555 datasheet. */
++static void test_reset_defaults(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT1), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_OUTPUT0), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_OUTPUT1), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_POLARITY0), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_POLARITY1), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_CONFIG0), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_CONFIG1), ==, 0xFF);
++}
++
++static void pca9555_register_nodes(void)
++{
++    QOSGraphEdgeOptions opts = {
++        .extra_device_opts = "address=0x20"
++    };
++    add_qi2c_address(&opts, &(QI2CAddress) { PCA9555_TEST_ADDR });
++
++    qos_node_create_driver("pca9555", i2c_device_create);
++    qos_node_consumes("pca9555", "i2c-bus", &opts);
++
++    qos_add_test("reset-defaults", "pca9555", test_reset_defaults, NULL);
++}
++
++libqos_init(pca9555_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0617-tests-qtest-pca9555-test-output-to-input-reflection-.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0617-tests-qtest-pca9555-test-output-to-input-reflection-.patch
@@ -1,0 +1,117 @@
+From f733eacd02f25bdb3b88bfc7dff2ab1a8c2995e3 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:03 +0200
+Subject: [PATCH 617/631] tests/qtest: pca9555: test output-to-input reflection
+ and pull-ups
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add tests covering the pin I/O semantics of the expander: output-driven
+pins reflected in the input register, the pull-up seen on input-configured
+pins, and the independence of the two 8-bit ports.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-11-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/pca9555-test.c | 75 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 75 insertions(+)
+
+diff --git a/tests/qtest/pca9555-test.c b/tests/qtest/pca9555-test.c
+index 5945c3441e9..6b085702c3c 100644
+--- a/tests/qtest/pca9555-test.c
++++ b/tests/qtest/pca9555-test.c
+@@ -28,6 +28,77 @@ static void test_reset_defaults(void *obj, void *data, QGuestAllocator *alloc)
+     g_assert_cmphex(i2c_get8(dev, PCA9535_CONFIG1), ==, 0xFF);
+ }
+ 
++/*
++ * When a pin is configured as output and driven low (output=0, config=0),
++ * the input register should reflect 0 for that pin.
++ * When driven high (output=1, config=0), input should reflect 1.
++ * When configured as input (config=1), PCA5555 pull-up makes it read 1.
++ */
++static void test_output_drives_input(void *obj, void *data,
++                                     QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    i2c_set8(dev, PCA9535_CONFIG0, 0xF0);
++    i2c_set8(dev, PCA9535_OUTPUT0, 0xFA);
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0xFA);
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT1), ==, 0xFF);
++
++    i2c_set8(dev, PCA9535_CONFIG0, 0x00);
++    i2c_set8(dev, PCA9535_OUTPUT0, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0x00);
++
++    i2c_set8(dev, PCA9535_OUTPUT0, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0xFF);
++}
++
++/*
++ * When all pins are inputs (config=0xFF) and no external driver,
++ * PCA9555 pull-ups should make the input register read all ones.
++ * Switching a pin to output mode with output=0 should drive it low.
++ */
++static void test_input_pullup(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT1), ==, 0xFF);
++
++    i2c_set8(dev, PCA9535_OUTPUT0, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0xFF);
++
++    i2c_set8(dev, PCA9535_CONFIG0, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0x00);
++}
++
++/*
++ * Test that both ports are independent: changing port 0 registers
++ * should not affect port 1 and vice versa.
++ */
++static void test_port_independence(void *obj, void *data,
++                                   QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    i2c_set8(dev, PCA9535_CONFIG0, 0x00);
++    i2c_set8(dev, PCA9535_OUTPUT0, 0x00);
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT1), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_CONFIG1), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_OUTPUT1), ==, 0xFF);
++
++    i2c_set8(dev, PCA9535_CONFIG1, 0x00);
++    i2c_set8(dev, PCA9535_OUTPUT1, 0xAA);
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT1), ==, 0xAA);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_OUTPUT0), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_OUTPUT1), ==, 0xAA);
++}
++
+ static void pca9555_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -39,6 +110,10 @@ static void pca9555_register_nodes(void)
+     qos_node_consumes("pca9555", "i2c-bus", &opts);
+ 
+     qos_add_test("reset-defaults", "pca9555", test_reset_defaults, NULL);
++    qos_add_test("output-drives-input", "pca9555", test_output_drives_input,
++                 NULL);
++    qos_add_test("input-pullup", "pca9555", test_input_pullup, NULL);
++    qos_add_test("port-independence", "pca9555", test_port_independence, NULL);
+ }
+ 
+ libqos_init(pca9555_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0618-tests-qtest-pca9555-test-polarity-inversion.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0618-tests-qtest-pca9555-test-polarity-inversion.patch
@@ -1,0 +1,85 @@
+From 79d25deaf2dbca17e6092177aa789e3b28f1f76d Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:04 +0200
+Subject: [PATCH 618/631] tests/qtest: pca9555: test polarity inversion
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add tests for the polarity inversion register: the inversion is applied
+when reading the INPUT register, both for input pins (pull-up) and for
+output-driven pins, and it does not affect the OUTPUT register readback.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-12-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/pca9555-test.c | 44 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
+
+diff --git a/tests/qtest/pca9555-test.c b/tests/qtest/pca9555-test.c
+index 6b085702c3c..2afa061bd2e 100644
+--- a/tests/qtest/pca9555-test.c
++++ b/tests/qtest/pca9555-test.c
+@@ -99,6 +99,46 @@ static void test_port_independence(void *obj, void *data,
+     g_assert_cmphex(i2c_get8(dev, PCA9535_OUTPUT1), ==, 0xAA);
+ }
+ 
++/*
++ * Polarity inversion: reading INPUT with polarity bits set should
++ * return the XOR of the actual input state and the polarity register.
++ */
++static void test_polarity_inversion(void *obj, void *data,
++                                    QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0xFF);
++
++    i2c_set8(dev, PCA9535_POLARITY0, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0x00);
++
++    i2c_set8(dev, PCA9535_POLARITY0, 0x0F);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0xF0);
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT1), ==, 0xFF);
++
++    i2c_set8(dev, PCA9535_POLARITY1, 0xAA);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT1), ==, 0x55);
++}
++
++/* Polarity inversion combined with output-driven pins. */
++static void test_polarity_with_output(void *obj, void *data,
++                                      QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    i2c_set8(dev, PCA9535_CONFIG0, 0x00);
++    i2c_set8(dev, PCA9535_OUTPUT0, 0xA5);
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0xA5);
++
++    i2c_set8(dev, PCA9535_POLARITY0, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_INPUT0), ==, 0x5A);
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_OUTPUT0), ==, 0xA5);
++}
++
+ static void pca9555_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -114,6 +154,10 @@ static void pca9555_register_nodes(void)
+                  NULL);
+     qos_add_test("input-pullup", "pca9555", test_input_pullup, NULL);
+     qos_add_test("port-independence", "pca9555", test_port_independence, NULL);
++    qos_add_test("polarity-inversion", "pca9555", test_polarity_inversion,
++                 NULL);
++    qos_add_test("polarity-with-output", "pca9555", test_polarity_with_output,
++                 NULL);
+ }
+ 
+ libqos_init(pca9555_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0619-tests-qtest-pca9555-test-auto-increment-and-command-.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0619-tests-qtest-pca9555-test-auto-increment-and-command-.patch
@@ -1,0 +1,131 @@
+From 26f108b46bae633a74b1129b9699b8db8c328852 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:05 +0200
+Subject: [PATCH 619/631] tests/qtest: pca9555: test auto-increment and command
+ wrapping
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add tests for the I2C command protocol of the GPIO variant: the
+auto-increment that toggles bit 0 within a register pair on reads and
+writes, and the 3-bit command wrapping that aliases out-of-range register
+addresses back into the register window.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-13-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/pca9555-test.c | 88 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 88 insertions(+)
+
+diff --git a/tests/qtest/pca9555-test.c b/tests/qtest/pca9555-test.c
+index 2afa061bd2e..84d771bcbb8 100644
+--- a/tests/qtest/pca9555-test.c
++++ b/tests/qtest/pca9555-test.c
+@@ -139,6 +139,87 @@ static void test_polarity_with_output(void *obj, void *data,
+     g_assert_cmphex(i2c_get8(dev, PCA9535_OUTPUT0), ==, 0xA5);
+ }
+ 
++/*
++ * The PCA9555 auto-increments by toggling bit 0 of the command pointer
++ * within a register pair. Reading two bytes from INPUT0 should yield
++ * INPUT0 then INPUT1.
++ */
++static void test_auto_increment_read(void *obj, void *data,
++                                     QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint8_t buf[2];
++
++    i2c_set8(dev, PCA9535_CONFIG0, 0x00);
++    i2c_set8(dev, PCA9535_CONFIG1, 0x00);
++    i2c_set8(dev, PCA9535_OUTPUT0, 0xAA);
++    i2c_set8(dev, PCA9535_OUTPUT1, 0x55);
++
++    i2c_read_block(dev, PCA9535_INPUT0, buf, 2);
++    g_assert_cmphex(buf[0], ==, 0xAA);
++    g_assert_cmphex(buf[1], ==, 0x55);
++
++    i2c_read_block(dev, PCA9535_OUTPUT0, buf, 2);
++    g_assert_cmphex(buf[0], ==, 0xAA);
++    g_assert_cmphex(buf[1], ==, 0x55);
++}
++
++/*
++ * Auto-increment write: writing two data bytes after a command byte
++ * should write to port 0 then port 1 of the addressed register pair.
++ */
++static void test_auto_increment_write(void *obj, void *data,
++                                      QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint8_t buf[2];
++
++    buf[0] = 0x12;
++    buf[1] = 0x34;
++    i2c_write_block(dev, PCA9535_OUTPUT0, buf, 2);
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_OUTPUT0), ==, 0x12);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_OUTPUT1), ==, 0x34);
++
++    buf[0] = 0x0F;
++    buf[1] = 0xF0;
++    i2c_write_block(dev, PCA9535_CONFIG0, buf, 2);
++
++    g_assert_cmphex(i2c_get8(dev, PCA9535_CONFIG0), ==, 0x0F);
++    g_assert_cmphex(i2c_get8(dev, PCA9535_CONFIG1), ==, 0xF0);
++}
++
++/*
++ * Auto-increment toggles within the pair: starting from port 1 should
++ * wrap back to port 0 (toggle bit 0).
++ */
++static void test_auto_increment_toggle(void *obj, void *data,
++                                       QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint8_t buf[2];
++
++    i2c_set8(dev, PCA9535_OUTPUT0, 0xAA);
++    i2c_set8(dev, PCA9535_OUTPUT1, 0x55);
++
++    i2c_read_block(dev, PCA9535_OUTPUT1, buf, 2);
++    g_assert_cmphex(buf[0], ==, 0x55);
++    g_assert_cmphex(buf[1], ==, 0xAA);
++}
++
++/*
++ * Verify the command byte wraps at 3 bits: register addresses
++ * beyond 7 should alias to the same register (bits [2:0] only).
++ */
++static void test_command_wrapping(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    i2c_set8(dev, PCA9535_OUTPUT0, 0x42);
++
++    g_assert_cmphex(i2c_get8(dev, 0x0A), ==, 0x42);
++}
++
+ static void pca9555_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -158,6 +239,13 @@ static void pca9555_register_nodes(void)
+                  NULL);
+     qos_add_test("polarity-with-output", "pca9555", test_polarity_with_output,
+                  NULL);
++    qos_add_test("auto-increment-read", "pca9555", test_auto_increment_read,
++                 NULL);
++    qos_add_test("auto-increment-write", "pca9555", test_auto_increment_write,
++                 NULL);
++    qos_add_test("auto-increment-toggle", "pca9555", test_auto_increment_toggle,
++                 NULL);
++    qos_add_test("command-wrapping", "pca9555", test_command_wrapping, NULL);
+ }
+ 
+ libqos_init(pca9555_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0620-tests-qtest-pca9552-test-behaviour-specific-to-the-L.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0620-tests-qtest-pca9552-test-behaviour-specific-to-the-L.patch
@@ -1,0 +1,127 @@
+From 607c0cfcef71ad2d2dbd1803eb85c3e62d1748fa Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:06 +0200
+Subject: [PATCH 620/631] tests/qtest: pca9552: test behaviour specific to the
+ LED variant
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The PCA9552 shares its device model with the PCA9535/PCA9555 GPIO
+expanders but decodes registers differently. Add tests for the behaviour
+that is specific to the LED variant and diverges from the PCA9555:
+
+  - the power-on reset defaults of the prescaler, PWM and LED-selector
+    registers;
+  - the prescaler/PWM registers (2-5), which are OUTPUT/POLARITY on the
+    PCA9555, as plain read/write storage;
+  - the auto-increment, which only advances when the AI command bit is set
+    and wraps modulo the full 10-register map (rather than toggling bit 0
+    within a register pair);
+  - the 4-bit command decode, where an out-of-range register reads back
+    0xFF instead of aliasing into the register window.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-14-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/pca9552-test.c | 76 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 76 insertions(+)
+
+diff --git a/tests/qtest/pca9552-test.c b/tests/qtest/pca9552-test.c
+index 74749576923..3718dfbd227 100644
+--- a/tests/qtest/pca9552-test.c
++++ b/tests/qtest/pca9552-test.c
+@@ -77,6 +77,76 @@ static void send_and_receive(void *obj, void *data, QGuestAllocator *alloc)
+     g_assert_cmphex(value, ==, 0xEF);
+ }
+ 
++/* Verify the power-on reset defaults. */
++static void test_reset_defaults(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *i2cdev = (QI2CDevice *)obj;
++
++    /* Prescalers, PWM duty cycles and LED selectors (all LEDs off) */
++    g_assert_cmphex(i2c_get8(i2cdev, PCA9552_PSC0), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(i2cdev, PCA9552_PWM0), ==, 0x80);
++    g_assert_cmphex(i2c_get8(i2cdev, PCA9552_PSC1), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(i2cdev, PCA9552_PWM1), ==, 0x80);
++    g_assert_cmphex(i2c_get8(i2cdev, PCA9552_LS0), ==, 0x55);
++    g_assert_cmphex(i2c_get8(i2cdev, PCA9552_LS1), ==, 0x55);
++    g_assert_cmphex(i2c_get8(i2cdev, PCA9552_LS2), ==, 0x55);
++    g_assert_cmphex(i2c_get8(i2cdev, PCA9552_LS3), ==, 0x55);
++
++    /* All LEDs off, so every pin floats high through its pull-up */
++    g_assert_cmphex(i2c_get8(i2cdev, PCA9552_INPUT0), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(i2cdev, PCA9552_INPUT1), ==, 0xFF);
++}
++
++/*
++ * The PCA9552 only advances the command pointer when the AI bit is set, and
++ * it wraps modulo the full 10-register map.
++ */
++static void test_autoinc_requires_ai_bit(void *obj, void *data,
++                                         QGuestAllocator *alloc)
++{
++    QI2CDevice *i2cdev = (QI2CDevice *)obj;
++    uint8_t reg;
++    uint8_t resp;
++
++    /*
++     * With the AI bit, reading from LS3 (register 9) rolls over to INPUT0
++     * (register 0), not to a sibling in a register pair. All LEDs are off
++     * after reset so the input ports read 0xFF.
++     */
++    reg = PCA9552_LS3 | PCA9552_AUTOINC;
++    qi2c_send(i2cdev, &reg, 1);
++    qi2c_recv(i2cdev, &resp, 1); /* LS3 */
++    g_assert_cmphex(resp, ==, 0x55);
++    qi2c_recv(i2cdev, &resp, 1); /* wraps to INPUT0 */
++    g_assert_cmphex(resp, ==, 0xFF);
++    qi2c_recv(i2cdev, &resp, 1); /* INPUT1 */
++    g_assert_cmphex(resp, ==, 0xFF);
++
++    /*
++     * Without the AI bit the pointer must not advance: repeated reads keep
++     * returning the same register.
++     */
++    i2c_set8(i2cdev, PCA9552_LS0, 0x54);
++    reg = PCA9552_LS0;
++    qi2c_send(i2cdev, &reg, 1);
++    qi2c_recv(i2cdev, &resp, 1);
++    g_assert_cmphex(resp, ==, 0x54);
++    qi2c_recv(i2cdev, &resp, 1);
++    g_assert_cmphex(resp, ==, 0x54);
++}
++
++/*
++ * The PCA9552 decodes a 4-bit command and has no register past LS3 (9), so
++ * addressing register 0x0A reads back 0xFF.
++ */
++static void test_command_out_of_range(void *obj, void *data,
++                                      QGuestAllocator *alloc)
++{
++    QI2CDevice *i2cdev = (QI2CDevice *)obj;
++
++    g_assert_cmphex(i2c_get8(i2cdev, 0x0A), ==, 0xFF);
++}
++
+ static void pca9552_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -89,5 +159,11 @@ static void pca9552_register_nodes(void)
+ 
+     qos_add_test("tx-rx", "pca9552", send_and_receive, NULL);
+     qos_add_test("rx-autoinc", "pca9552", receive_autoinc, NULL);
++    qos_add_test("reset-defaults", "pca9552", test_reset_defaults, NULL);
++    qos_add_test("autoinc-requires-ai-bit", "pca9552",
++                 test_autoinc_requires_ai_bit, NULL);
++    qos_add_test("command-out-of-range", "pca9552", test_command_out_of_range,
++                 NULL);
+ }
++
+ libqos_init(pca9552_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0621-hw-gpio-pca9554-add-PCA9536-support.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0621-hw-gpio-pca9554-add-PCA9536-support.patch
@@ -1,0 +1,233 @@
+From b1b4b3d10c181d55e73a621c2100e78e914eafd0 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:07 +0200
+Subject: [PATCH 621/631] hw/gpio: pca9554: add PCA9536 support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The PCA9536 is a 4-bit I/O expander that's register-compatible with the
+PCA9554 but only has 4 pins.  Rather than duplicating the whole driver,
+make the existing PCA9554 model parameterizable and register PCA9536 as
+a subtype.
+
+Introduce a PCA9554Class with a pin_count property, and replace every
+hard-coded PCA9554_PIN_COUNT reference in the driver with the class
+value.  The reset function now computes the correct pin mask from
+pin_count instead of assuming 0xFF.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-15-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9554.c         | 79 ++++++++++++++++++++++++++-------------
+ include/hw/gpio/pca9554.h |  2 +
+ 2 files changed, 54 insertions(+), 27 deletions(-)
+
+diff --git a/hw/gpio/pca9554.c b/hw/gpio/pca9554.c
+index 8427e01e9b2..b44ec0d9991 100644
+--- a/hw/gpio/pca9554.c
++++ b/hw/gpio/pca9554.c
+@@ -24,6 +24,8 @@ struct PCA9554Class {
+     /*< private >*/
+     I2CSlaveClass parent_class;
+     /*< public >*/
++
++    uint8_t pin_count;
+ };
+ typedef struct PCA9554Class PCA9554Class;
+ 
+@@ -37,12 +39,13 @@ static const char *pin_state[] = {"low", "high"};
+ 
+ static void pca9554_update_pin_input(PCA9554State *s)
+ {
++    PCA9554Class *pc = PCA9554_GET_CLASS(s);
+     int i;
+     uint8_t config = s->regs[PCA9554_CONFIG];
+     uint8_t output = s->regs[PCA9554_OUTPUT];
+     uint8_t internal_state = config | output;
+ 
+-    for (i = 0; i < PCA9554_PIN_COUNT; i++) {
++    for (i = 0; i < pc->pin_count; i++) {
+         uint8_t bit_mask = 1 << i;
+         uint8_t internal_pin_state = (internal_state >> i) & 0x1;
+         uint8_t old_value = s->regs[PCA9554_INPUT] & bit_mask;
+@@ -67,7 +70,7 @@ static void pca9554_update_pin_input(PCA9554State *s)
+             break;
+         }
+ 
+-        /* update irq state only if pin state changed */
++        /* drive the per-pin GPIO output only if the pin level changed */
+         new_value = s->regs[PCA9554_INPUT] & bit_mask;
+         if (new_value != old_value) {
+             if (new_value) {
+@@ -99,6 +102,12 @@ static uint8_t pca9554_read(PCA9554State *s, uint8_t reg)
+ 
+ static void pca9554_write(PCA9554State *s, uint8_t reg, uint8_t data)
+ {
++    PCA9554Class *pc = PCA9554_GET_CLASS(s);
++    uint8_t pin_mask = (1 << pc->pin_count) - 1;
++
++    /* Variants narrower than 8 bits ignore the unimplemented upper pins. */
++    data &= pin_mask;
++
+     switch (reg) {
+     case PCA9554_OUTPUT:
+     case PCA9554_CONFIG:
+@@ -157,7 +166,7 @@ static void pca9554_get_pin(Object *obj, Visitor *v, const char *name,
+         error_setg(errp, "%s: error reading %s", __func__, name);
+         return;
+     }
+-    if (pin < 0 || pin >= PCA9554_PIN_COUNT) {
++    if (pin < 0 || pin >= PCA9554_GET_CLASS(s)->pin_count) {
+         error_setg(errp, "%s invalid pin %s", __func__, name);
+         return;
+     }
+@@ -184,7 +193,7 @@ static void pca9554_set_pin(Object *obj, Visitor *v, const char *name,
+         error_setg(errp, "%s: error reading %s", __func__, name);
+         return;
+     }
+-    if (pin < 0 || pin >= PCA9554_PIN_COUNT) {
++    if (pin < 0 || pin >= PCA9554_GET_CLASS(s)->pin_count) {
+         error_setg(errp, "%s invalid pin %s", __func__, name);
+         return;
+     }
+@@ -232,13 +241,15 @@ static const VMStateDescription pca9554_vmstate = {
+ static void pca9554_reset(DeviceState *dev)
+ {
+     PCA9554State *s = PCA9554(dev);
++    PCA9554Class *pc = PCA9554_GET_CLASS(s);
++    uint8_t pin_mask = (1 << pc->pin_count) - 1;
+ 
+-    s->regs[PCA9554_INPUT] = 0xFF;
+-    s->regs[PCA9554_OUTPUT] = 0xFF;
++    s->regs[PCA9554_INPUT] = pin_mask;
++    s->regs[PCA9554_OUTPUT] = pin_mask;
+     s->regs[PCA9554_POLARITY] = 0x0; /* No pins are inverted */
+-    s->regs[PCA9554_CONFIG] = 0xFF; /* All pins are inputs */
++    s->regs[PCA9554_CONFIG] = pin_mask; /* All pins are inputs */
+ 
+-    memset(s->ext_state, PCA9554_PIN_HIZ, PCA9554_PIN_COUNT);
++    memset(s->ext_state, PCA9554_PIN_HIZ, pc->pin_count);
+     pca9554_update_pin_input(s);
+ 
+     s->pointer = 0x0;
+@@ -247,9 +258,10 @@ static void pca9554_reset(DeviceState *dev)
+ 
+ static void pca9554_initfn(Object *obj)
+ {
++    PCA9554Class *pc = PCA9554_GET_CLASS(obj);
+     int pin;
+ 
+-    for (pin = 0; pin < PCA9554_PIN_COUNT; pin++) {
++    for (pin = 0; pin < pc->pin_count; pin++) {
+         char *name;
+ 
+         name = g_strdup_printf("pin%d", pin);
+@@ -269,23 +281,24 @@ static void pca9554_set_ext_state(PCA9554State *s, int pin, int level)
+ 
+ static void pca9554_gpio_in_handler(void *opaque, int pin, int level)
+ {
+-
+     PCA9554State *s = PCA9554(opaque);
++    PCA9554Class *pc = PCA9554_GET_CLASS(s);
+ 
+-    assert((pin >= 0) && (pin < PCA9554_PIN_COUNT));
++    assert((pin >= 0) && (pin < pc->pin_count));
+     pca9554_set_ext_state(s, pin, level);
+ }
+ 
+ static void pca9554_realize(DeviceState *dev, Error **errp)
+ {
+     PCA9554State *s = PCA9554(dev);
++    PCA9554Class *pc = PCA9554_GET_CLASS(s);
+ 
+     if (!s->description) {
+-        s->description = g_strdup("pca9554");
++        s->description = g_strdup(object_get_typename(OBJECT(dev)));
+     }
+ 
+-    qdev_init_gpio_out(dev, s->gpio_out, PCA9554_PIN_COUNT);
+-    qdev_init_gpio_in(dev, pca9554_gpio_in_handler, PCA9554_PIN_COUNT);
++    qdev_init_gpio_out(dev, s->gpio_out, pc->pin_count);
++    qdev_init_gpio_in(dev, pca9554_gpio_in_handler, pc->pin_count);
+ }
+ 
+ static const Property pca9554_properties[] = {
+@@ -296,6 +309,7 @@ static void pca9554_class_init(ObjectClass *klass, const void *data)
+ {
+     DeviceClass *dc = DEVICE_CLASS(klass);
+     I2CSlaveClass *k = I2C_SLAVE_CLASS(klass);
++    PCA9554Class *pc = PCA9554_CLASS(klass);
+ 
+     k->event = pca9554_event;
+     k->recv = pca9554_recv;
+@@ -304,21 +318,32 @@ static void pca9554_class_init(ObjectClass *klass, const void *data)
+     device_class_set_legacy_reset(dc, pca9554_reset);
+     dc->vmsd = &pca9554_vmstate;
+     device_class_set_props(dc, pca9554_properties);
++
++    pc->pin_count = PCA9554_PIN_COUNT;
+ }
+ 
+-static const TypeInfo pca9554_info = {
+-    .name          = TYPE_PCA9554,
+-    .parent        = TYPE_I2C_SLAVE,
+-    .instance_init = pca9554_initfn,
+-    .instance_size = sizeof(PCA9554State),
+-    .class_init    = pca9554_class_init,
+-    .class_size    = sizeof(PCA9554Class),
+-    .abstract      = false,
+-};
+-
+-static void pca9554_register_types(void)
++static void pca9536_class_init(ObjectClass *klass, const void *data)
+ {
+-    type_register_static(&pca9554_info);
++    PCA9554Class *pc = PCA9554_CLASS(klass);
++
++    pc->pin_count = PCA9536_PIN_COUNT;
+ }
+ 
+-type_init(pca9554_register_types)
++static const TypeInfo pca9554_types[] = {
++    {
++        .name          = TYPE_PCA9554,
++        .parent        = TYPE_I2C_SLAVE,
++        .instance_init = pca9554_initfn,
++        .instance_size = sizeof(PCA9554State),
++        .class_init    = pca9554_class_init,
++        .class_size    = sizeof(PCA9554Class),
++        .abstract      = false,
++    },
++    {
++        .name          = TYPE_PCA9536,
++        .parent        = TYPE_PCA9554,
++        .class_init    = pca9536_class_init,
++    }
++};
++
++DEFINE_TYPES(pca9554_types);
+diff --git a/include/hw/gpio/pca9554.h b/include/hw/gpio/pca9554.h
+index 54bfc4c4c7a..c09108e8b65 100644
+--- a/include/hw/gpio/pca9554.h
++++ b/include/hw/gpio/pca9554.h
+@@ -12,12 +12,14 @@
+ #include "qom/object.h"
+ 
+ #define TYPE_PCA9554 "pca9554"
++#define TYPE_PCA9536 "pca9536"
+ typedef struct PCA9554State PCA9554State;
+ DECLARE_INSTANCE_CHECKER(PCA9554State, PCA9554,
+                          TYPE_PCA9554)
+ 
+ #define PCA9554_NR_REGS 4
+ #define PCA9554_PIN_COUNT 8
++#define PCA9536_PIN_COUNT 4
+ 
+ struct PCA9554State {
+     /*< private >*/
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0622-hw-gpio-pca9554-add-hw-dir-property-honoring-the-con.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0622-hw-gpio-pca9554-add-hw-dir-property-honoring-the-con.patch
@@ -1,0 +1,167 @@
+From 770199e88db2830fb9624159927598b10f3a79ed Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:08 +0200
+Subject: [PATCH 622/631] hw/gpio: pca9554: add hw-dir property honoring the
+ configured pin direction
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The pinN QOM accessors are meant to let external agents observe and
+stimulate the expander's pins, but their default behaviour does not
+match real hardware:
+
+ - to "drive" a pin, set_pin writes the OUTPUT register and then clears
+   the pin's Configuration bit to force it into output mode. On a real
+   device the pin direction is owned solely by the host (programmed
+   through the Configuration register over I2C); an external agent can
+   neither flip a pin's direction nor impose a level on a pin the host
+   drives as an output -- the latter is a voltage conflict, not a legal
+   operation.
+ - get_pin returns a CONFIG|OUTPUT composite, i.e. the guest's intent,
+   rather than the level actually sampled on the pin.
+
+The PCA9555 GPIO variant (hw/gpio/pca9552.c) already models this
+correctly and unconditionally: only input-configured pins can be driven
+from outside, and reads return the sampled INPUT register.
+
+Add a "hw-dir" property to bring the pca9554 pin accessors in line with
+the hardware (and with the PCA9555 model), without changing the
+behaviour seen by existing users:
+
+ - hw-dir=true: set_pin only drives pins the guest has configured as
+   inputs; a set on an output pin is refused with a LOG_UNIMP warning.
+   get_pin returns the sampled INPUT register.
+ - hw-dir=false (default): keeps the legacy, non-conformant behaviour
+   for backward compatibility.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-16-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9554.c         | 65 +++++++++++++++++++++++++--------------
+ include/hw/gpio/pca9554.h |  1 +
+ 2 files changed, 43 insertions(+), 23 deletions(-)
+
+diff --git a/hw/gpio/pca9554.c b/hw/gpio/pca9554.c
+index b44ec0d9991..ed38fe102b1 100644
+--- a/hw/gpio/pca9554.c
++++ b/hw/gpio/pca9554.c
+@@ -154,6 +154,14 @@ static int pca9554_event(I2CSlave *i2c, enum i2c_event event)
+     return 0;
+ }
+ 
++static void pca9554_set_ext_state(PCA9554State *s, int pin, int level)
++{
++    if (s->ext_state[pin] != level) {
++        s->ext_state[pin] = level;
++        pca9554_update_pin_input(s);
++    }
++}
++
+ static void pca9554_get_pin(Object *obj, Visitor *v, const char *name,
+                             void *opaque, Error **errp)
+ {
+@@ -171,9 +179,13 @@ static void pca9554_get_pin(Object *obj, Visitor *v, const char *name,
+         return;
+     }
+ 
+-    state = pca9554_read(s, PCA9554_CONFIG);
+-    state |= pca9554_read(s, PCA9554_OUTPUT);
+-    state = (state >> pin) & 0x1;
++    /*
++     * Report the physical pin level. The input register is kept in sync by
++     * pca9554_update_pin_input(): output pins mirror the OUTPUT register and
++     * input pins reflect the externally driven (or pulled-up) level, so it
++     * holds the wire level regardless of the configured direction.
++     */
++    state = (s->regs[PCA9554_INPUT] >> pin) & 0x1;
+     visit_type_str(v, name, (char **)&pin_state[state], errp);
+ }
+ 
+@@ -208,20 +220,34 @@ static void pca9554_set_pin(Object *obj, Visitor *v, const char *name,
+         return;
+     }
+ 
+-    /* First, modify the output register bit */
+-    val = pca9554_read(s, PCA9554_OUTPUT);
+-    mask = 0x1 << pin;
+-    if (state == PCA9554_PIN_LOW) {
+-        val &= ~(mask);
++    if (s->hw_dir) {
++        /* Warn and ignore if the guest has configured this pin as output */
++        if (!((s->regs[PCA9554_CONFIG] >> pin) & 0x1)) {
++            qemu_log_mask(LOG_UNIMP,
++                          "%s: pin %d is configured as output, "
++                          "ignoring external set\n",
++                          s->description, pin);
++            return;
++        }
++        /* Drive the external input level */
++        pca9554_set_ext_state(s, pin, state != PCA9554_PIN_LOW);
+     } else {
+-        val |= mask;
+-    }
+-    pca9554_write(s, PCA9554_OUTPUT, val);
++        /* Legacy behavior: force output mode and drive */
++        /* First, modify the output register bit */
++        val = pca9554_read(s, PCA9554_OUTPUT);
++        mask = 0x1 << pin;
++        if (state == PCA9554_PIN_LOW) {
++            val &= ~(mask);
++        } else {
++            val |= mask;
++        }
++        pca9554_write(s, PCA9554_OUTPUT, val);
+ 
+-    /* Then, clear the config register bit for output mode */
+-    val = pca9554_read(s, PCA9554_CONFIG);
+-    val &= ~mask;
+-    pca9554_write(s, PCA9554_CONFIG, val);
++        /* Then, clear the config register bit for output mode */
++        val = pca9554_read(s, PCA9554_CONFIG);
++        val &= ~mask;
++        pca9554_write(s, PCA9554_CONFIG, val);
++    }
+ }
+ 
+ static const VMStateDescription pca9554_vmstate = {
+@@ -271,14 +297,6 @@ static void pca9554_initfn(Object *obj)
+     }
+ }
+ 
+-static void pca9554_set_ext_state(PCA9554State *s, int pin, int level)
+-{
+-    if (s->ext_state[pin] != level) {
+-        s->ext_state[pin] = level;
+-        pca9554_update_pin_input(s);
+-    }
+-}
+-
+ static void pca9554_gpio_in_handler(void *opaque, int pin, int level)
+ {
+     PCA9554State *s = PCA9554(opaque);
+@@ -303,6 +321,7 @@ static void pca9554_realize(DeviceState *dev, Error **errp)
+ 
+ static const Property pca9554_properties[] = {
+     DEFINE_PROP_STRING("description", PCA9554State, description),
++    DEFINE_PROP_BOOL("hw-dir", PCA9554State, hw_dir, false),
+ };
+ 
+ static void pca9554_class_init(ObjectClass *klass, const void *data)
+diff --git a/include/hw/gpio/pca9554.h b/include/hw/gpio/pca9554.h
+index c09108e8b65..ac835371aac 100644
+--- a/include/hw/gpio/pca9554.h
++++ b/include/hw/gpio/pca9554.h
+@@ -33,6 +33,7 @@ struct PCA9554State {
+     qemu_irq gpio_out[PCA9554_PIN_COUNT];
+     uint8_t ext_state[PCA9554_PIN_COUNT];
+     char *description; /* For debugging purpose only */
++    bool hw_dir; /* Honor pin direction */
+ };
+ 
+ #endif
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0623-hw-gpio-pca9554-reflect-push-pull-outputs-in-the-inp.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0623-hw-gpio-pca9554-reflect-push-pull-outputs-in-the-inp.patch
@@ -1,0 +1,85 @@
+From d08f268a9e4fa59f483582302f6b05bfefe765d1 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:09 +0200
+Subject: [PATCH 623/631] hw/gpio: pca9554: reflect push-pull outputs in the
+ input register
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+pca9554_update_pin_input() derived the pin level from CONFIG | OUTPUT,
+which treated an output driven high as Hi-Z and let ext_state pull it
+low. The PCA9554/PCA9536 output stage is push-pull, so a pin configured
+as an output drives the OUTPUT register level regardless of any external
+agent. Reflect the output value directly for output pins and keep the
+pull-up/ext_state behaviour for input pins, matching the PCA9555 GPIO
+variant.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-17-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9554.c | 29 +++++++++--------------------
+ 1 file changed, 9 insertions(+), 20 deletions(-)
+
+diff --git a/hw/gpio/pca9554.c b/hw/gpio/pca9554.c
+index ed38fe102b1..d4746719f91 100644
+--- a/hw/gpio/pca9554.c
++++ b/hw/gpio/pca9554.c
+@@ -43,43 +43,32 @@ static void pca9554_update_pin_input(PCA9554State *s)
+     int i;
+     uint8_t config = s->regs[PCA9554_CONFIG];
+     uint8_t output = s->regs[PCA9554_OUTPUT];
+-    uint8_t internal_state = config | output;
+ 
+     for (i = 0; i < pc->pin_count; i++) {
+         uint8_t bit_mask = 1 << i;
+-        uint8_t internal_pin_state = (internal_state >> i) & 0x1;
+         uint8_t old_value = s->regs[PCA9554_INPUT] & bit_mask;
+         uint8_t new_value;
+ 
+-        switch (internal_pin_state) {
+-        case PCA9554_PIN_LOW:
+-            s->regs[PCA9554_INPUT] &= ~bit_mask;
+-            break;
+-        case PCA9554_PIN_HIZ:
++        if (config & bit_mask) {
+             /*
+-             * pullup sets it to a logical 1 unless
+-             * external device drives it low.
++             * Input: the pin is Hi-Z with a pull-up, so it reads high
++             * unless an external device drives it low.
+              */
+             if (s->ext_state[i] == PCA9554_PIN_LOW) {
+                 s->regs[PCA9554_INPUT] &= ~bit_mask;
+             } else {
+-                s->regs[PCA9554_INPUT] |=  bit_mask;
++                s->regs[PCA9554_INPUT] |= bit_mask;
+             }
+-            break;
+-        default:
+-            break;
++        } else {
++            /* Output: the push-pull stage drives the output register level. */
++            s->regs[PCA9554_INPUT] = (s->regs[PCA9554_INPUT] & ~bit_mask) |
++                                     (output & bit_mask);
+         }
+ 
+         /* drive the per-pin GPIO output only if the pin level changed */
+         new_value = s->regs[PCA9554_INPUT] & bit_mask;
+         if (new_value != old_value) {
+-            if (new_value) {
+-                /* changed from 0 to 1 */
+-                qemu_set_irq(s->gpio_out[i], 1);
+-            } else {
+-                /* changed from 1 to 0 */
+-                qemu_set_irq(s->gpio_out[i], 0);
+-            }
++            qemu_set_irq(s->gpio_out[i], !!new_value);
+         }
+     }
+ }
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0624-hw-gpio-pca9554-expose-pin-d-as-a-string-property.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0624-hw-gpio-pca9554-expose-pin-d-as-a-string-property.patch
@@ -1,0 +1,38 @@
+From 9b9118fb11d793e8d67f101fca7465e25135005e Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:10 +0200
+Subject: [PATCH 624/631] hw/gpio: pca9554: expose pin%d as a string property
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The pinN properties are accessed with visit_type_str() (values "low" and
+"high"), but were registered as type "bool", so introspection advertised
+a boolean while the accessors require a string. Register them as "str",
+matching the PCA9555 GPIO variant.
+
+Fixes: de0c7d543bca ("misc: Add a pca9554 GPIO device model")
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-18-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/gpio/pca9554.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hw/gpio/pca9554.c b/hw/gpio/pca9554.c
+index d4746719f91..904698cdce8 100644
+--- a/hw/gpio/pca9554.c
++++ b/hw/gpio/pca9554.c
+@@ -280,7 +280,7 @@ static void pca9554_initfn(Object *obj)
+         char *name;
+ 
+         name = g_strdup_printf("pin%d", pin);
+-        object_property_add(obj, name, "bool", pca9554_get_pin, pca9554_set_pin,
++        object_property_add(obj, name, "str", pca9554_get_pin, pca9554_set_pin,
+                             NULL, NULL);
+         g_free(name);
+     }
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0625-tests-qtest-add-PCA9554-register-access-tests.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0625-tests-qtest-add-PCA9554-register-access-tests.patch
@@ -1,0 +1,84 @@
+From 752f1d550cea79831322ef4bfe83b5fde0963d64 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:11 +0200
+Subject: [PATCH 625/631] tests/qtest: add PCA9554 register access tests
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add a qtest for the PCA9554 8-bit I/O port expander exercising the basic
+register access: power-on reset defaults and read/write of the OUTPUT,
+CONFIG and POLARITY registers.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-19-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/meson.build    |  1 +
+ tests/qtest/pca9554-test.c | 41 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 42 insertions(+)
+ create mode 100644 tests/qtest/pca9554-test.c
+
+diff --git a/tests/qtest/meson.build b/tests/qtest/meson.build
+index e92130bd04d..4d81857174a 100644
+--- a/tests/qtest/meson.build
++++ b/tests/qtest/meson.build
+@@ -319,6 +319,7 @@ qos_test_ss.add(
+   'tulip-test.c',
+   'nvme-test.c',
+   'pca9552-test.c',
++  'pca9554-test.c',
+   'pca9555-test.c',
+   'pci-test.c',
+   'pcnet-test.c',
+diff --git a/tests/qtest/pca9554-test.c b/tests/qtest/pca9554-test.c
+new file mode 100644
+index 00000000000..a5f213a59cc
+--- /dev/null
++++ b/tests/qtest/pca9554-test.c
+@@ -0,0 +1,41 @@
++/*
++ * QTest testcase for the PCA9554/PCA9536 I/O port expanders
++ *
++ * Copyright (c) Meta Platforms, Inc. and affiliates. (http://www.meta.com)
++ *
++ * SPDX-License-Identifier: GPL-2.0-or-later
++ */
++
++#include "qemu/osdep.h"
++#include "hw/gpio/pca9554_regs.h"
++#include "libqos/i2c.h"
++#include "libqos/qgraph.h"
++
++#define PCA9554_TEST_ADDR 0x20
++
++/* Verify power-on reset defaults match the PCA9554 datasheet. */
++static void test_reset_defaults(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    /* All pins are inputs, pulled high, with no polarity inversion. */
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_OUTPUT), ==, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_POLARITY), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_CONFIG), ==, 0xFF);
++}
++
++static void pca9554_register_nodes(void)
++{
++    QOSGraphEdgeOptions opts = {
++        .extra_device_opts = "address=0x20"
++    };
++    add_qi2c_address(&opts, &(QI2CAddress) { PCA9554_TEST_ADDR });
++
++    qos_node_create_driver("pca9554", i2c_device_create);
++    qos_node_consumes("pca9554", "i2c-bus", &opts);
++
++    qos_add_test("reset-defaults", "pca9554", test_reset_defaults, NULL);
++}
++
++libqos_init(pca9554_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0626-tests-qtest-pca9554-test-output-to-input-reflection-.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0626-tests-qtest-pca9554-test-output-to-input-reflection-.patch
@@ -1,0 +1,87 @@
+From e7cb637aa169c5b02d1e9818065fa974ed2f30e9 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:12 +0200
+Subject: [PATCH 626/631] tests/qtest: pca9554: test output-to-input reflection
+ and pull-ups
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Check that a pin configured as output drives its OUTPUT register level
+onto the pin (push-pull) as reflected by the INPUT register, and that a
+pin configured as input floats high through its pull-up.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-20-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/pca9554-test.c | 45 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 45 insertions(+)
+
+diff --git a/tests/qtest/pca9554-test.c b/tests/qtest/pca9554-test.c
+index a5f213a59cc..ce6e90f3f88 100644
+--- a/tests/qtest/pca9554-test.c
++++ b/tests/qtest/pca9554-test.c
+@@ -25,6 +25,48 @@ static void test_reset_defaults(void *obj, void *data, QGuestAllocator *alloc)
+     g_assert_cmphex(i2c_get8(dev, PCA9554_CONFIG), ==, 0xFF);
+ }
+ 
++/*
++ * A pin configured as output (config=0) drives its OUTPUT register level onto
++ * the pin (push-pull), which the INPUT register reflects. A pin configured as
++ * input (config=1) floats high through its pull-up.
++ */
++static void test_output_drives_input(void *obj, void *data,
++                                     QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    /* Low nibble output, high nibble input (pull-up). */
++    i2c_set8(dev, PCA9554_CONFIG, 0xF0);
++    i2c_set8(dev, PCA9554_OUTPUT, 0xFA);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0xFA);
++
++    /* All outputs, driven low then high. */
++    i2c_set8(dev, PCA9554_CONFIG, 0x00);
++    i2c_set8(dev, PCA9554_OUTPUT, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0x00);
++
++    i2c_set8(dev, PCA9554_OUTPUT, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0xFF);
++}
++
++/*
++ * With all pins configured as inputs the pull-ups make the INPUT register read
++ * all ones regardless of the OUTPUT register; switching a pin to output with
++ * output=0 drives it low.
++ */
++static void test_input_pullup(void *obj, void *data, QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0xFF);
++
++    i2c_set8(dev, PCA9554_OUTPUT, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0xFF);
++
++    i2c_set8(dev, PCA9554_CONFIG, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0x00);
++}
++
+ static void pca9554_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -36,6 +78,9 @@ static void pca9554_register_nodes(void)
+     qos_node_consumes("pca9554", "i2c-bus", &opts);
+ 
+     qos_add_test("reset-defaults", "pca9554", test_reset_defaults, NULL);
++    qos_add_test("output-drives-input", "pca9554", test_output_drives_input,
++                 NULL);
++    qos_add_test("input-pullup", "pca9554", test_input_pullup, NULL);
+ }
+ 
+ libqos_init(pca9554_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0627-tests-qtest-pca9554-test-polarity-inversion.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0627-tests-qtest-pca9554-test-polarity-inversion.patch
@@ -1,0 +1,80 @@
+From 8b6d883c7e0e8c3c55d8302825bda34db6ad2a60 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:13 +0200
+Subject: [PATCH 627/631] tests/qtest: pca9554: test polarity inversion
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Verify that the polarity register inverts the value read back from the
+INPUT register, both on pulled-up inputs and on output-driven pins, while
+leaving the OUTPUT register itself unchanged.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-21-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/pca9554-test.c | 39 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 39 insertions(+)
+
+diff --git a/tests/qtest/pca9554-test.c b/tests/qtest/pca9554-test.c
+index ce6e90f3f88..74237df611e 100644
+--- a/tests/qtest/pca9554-test.c
++++ b/tests/qtest/pca9554-test.c
+@@ -67,6 +67,41 @@ static void test_input_pullup(void *obj, void *data, QGuestAllocator *alloc)
+     g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0x00);
+ }
+ 
++/*
++ * Polarity inversion: reading INPUT returns the XOR of the pin levels and the
++ * polarity register.
++ */
++static void test_polarity_inversion(void *obj, void *data,
++                                    QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0xFF);
++
++    i2c_set8(dev, PCA9554_POLARITY, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0x00);
++
++    i2c_set8(dev, PCA9554_POLARITY, 0x0F);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0xF0);
++}
++
++/* Polarity inversion combined with output-driven pins. */
++static void test_polarity_with_output(void *obj, void *data,
++                                      QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    i2c_set8(dev, PCA9554_CONFIG, 0x00);
++    i2c_set8(dev, PCA9554_OUTPUT, 0xA5);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0xA5);
++
++    i2c_set8(dev, PCA9554_POLARITY, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0x5A);
++
++    /* Inversion only affects the INPUT read, not the OUTPUT register. */
++    g_assert_cmphex(i2c_get8(dev, PCA9554_OUTPUT), ==, 0xA5);
++}
++
+ static void pca9554_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -81,6 +116,10 @@ static void pca9554_register_nodes(void)
+     qos_add_test("output-drives-input", "pca9554", test_output_drives_input,
+                  NULL);
+     qos_add_test("input-pullup", "pca9554", test_input_pullup, NULL);
++    qos_add_test("polarity-inversion", "pca9554", test_polarity_inversion,
++                 NULL);
++    qos_add_test("polarity-with-output", "pca9554", test_polarity_with_output,
++                 NULL);
+ }
+ 
+ libqos_init(pca9554_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0628-tests-qtest-pca9554-test-absence-of-command-auto-inc.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0628-tests-qtest-pca9554-test-absence-of-command-auto-inc.patch
@@ -1,0 +1,75 @@
+From 6f07e6862606a6d68dd29b66906ae90639136e48 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:14 +0200
+Subject: [PATCH 628/631] tests/qtest: pca9554: test absence of command
+ auto-increment
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The PCA9554 selects one of its four registers with a single command byte
+and does not auto-increment the register pointer, so a multi-byte I2C
+transfer keeps addressing the register chosen by the command byte instead
+of walking through the register map.
+
+Add a test covering this: a two-byte read returns the addressed register
+twice, and a two-byte write updates only that register, leaving its
+neighbour untouched.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-22-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/pca9554-test.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/tests/qtest/pca9554-test.c b/tests/qtest/pca9554-test.c
+index 74237df611e..0da1f3304b9 100644
+--- a/tests/qtest/pca9554-test.c
++++ b/tests/qtest/pca9554-test.c
+@@ -102,6 +102,33 @@ static void test_polarity_with_output(void *obj, void *data,
+     g_assert_cmphex(i2c_get8(dev, PCA9554_OUTPUT), ==, 0xA5);
+ }
+ 
++/*
++ * The PCA9554 has no auto-increment: the command pointer never advances, so
++ * multi-byte reads and writes all target the addressed register.
++ */
++static void test_no_autoincrement(void *obj, void *data,
++                                  QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++    uint8_t buf[2];
++
++    /* Distinct values in adjacent registers. */
++    i2c_set8(dev, PCA9554_OUTPUT, 0xAA);
++    i2c_set8(dev, PCA9554_POLARITY, 0x33);
++
++    /* Two reads from OUTPUT return OUTPUT twice, not OUTPUT then POLARITY. */
++    i2c_read_block(dev, PCA9554_OUTPUT, buf, 2);
++    g_assert_cmphex(buf[0], ==, 0xAA);
++    g_assert_cmphex(buf[1], ==, 0xAA);
++
++    /* The second written byte overwrites OUTPUT; POLARITY is untouched. */
++    buf[0] = 0x12;
++    buf[1] = 0x34;
++    i2c_write_block(dev, PCA9554_OUTPUT, buf, 2);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_OUTPUT), ==, 0x34);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_POLARITY), ==, 0x33);
++}
++
+ static void pca9554_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -120,6 +147,7 @@ static void pca9554_register_nodes(void)
+                  NULL);
+     qos_add_test("polarity-with-output", "pca9554", test_polarity_with_output,
+                  NULL);
++    qos_add_test("no-autoincrement", "pca9554", test_no_autoincrement, NULL);
+ }
+ 
+ libqos_init(pca9554_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0629-tests-qtest-pca9554-test-the-PCA9536-4-bit-variant.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0629-tests-qtest-pca9554-test-the-PCA9536-4-bit-variant.patch
@@ -1,0 +1,111 @@
+From 86150abb0f7ff2e5fac0b71ee2f7f4cc90b39054 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:15 +0200
+Subject: [PATCH 629/631] tests/qtest: pca9554: test the PCA9536 4-bit variant
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The PCA9536 shares the PCA9554 register map and code path but exposes
+only four pins. Add a pca9536 node and check its reset defaults and
+output-to-input reflection are masked to the low nibble.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Glenn Miles <milesg@linux.ibm.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-23-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ tests/qtest/pca9554-test.c | 70 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 70 insertions(+)
+
+diff --git a/tests/qtest/pca9554-test.c b/tests/qtest/pca9554-test.c
+index 0da1f3304b9..5366e719845 100644
+--- a/tests/qtest/pca9554-test.c
++++ b/tests/qtest/pca9554-test.c
+@@ -129,6 +129,66 @@ static void test_no_autoincrement(void *obj, void *data,
+     g_assert_cmphex(i2c_get8(dev, PCA9554_POLARITY), ==, 0x33);
+ }
+ 
++/*
++ * The PCA9536 shares the PCA9554 register map but only has four pins, so its
++ * reset defaults and pin logic are masked to the low nibble.
++ */
++static void test_pca9536_reset_defaults(void *obj, void *data,
++                                        QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0x0F);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_OUTPUT), ==, 0x0F);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_POLARITY), ==, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_CONFIG), ==, 0x0F);
++}
++
++/* Only the four low pins are driven; the upper nibble stays low. */
++static void test_pca9536_output_drives_input(void *obj, void *data,
++                                             QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    i2c_set8(dev, PCA9554_CONFIG, 0x00);
++
++    i2c_set8(dev, PCA9554_OUTPUT, 0x0A);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0x0A);
++
++    i2c_set8(dev, PCA9554_OUTPUT, 0x00);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0x00);
++}
++
++/*
++ * The four upper bits address pins that do not exist on the PCA9536, so writes
++ * to the register map discard them: the writable registers read back with bits
++ * [7:4] cleared, and driving them onto the pins never surfaces in INPUT.
++ */
++static void test_pca9536_ignores_upper_bits(void *obj, void *data,
++                                            QGuestAllocator *alloc)
++{
++    QI2CDevice *dev = (QI2CDevice *)obj;
++
++    /* Bits [7:4] are dropped on write; bits [3:0] survive. */
++    i2c_set8(dev, PCA9554_OUTPUT, 0xFA);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_OUTPUT), ==, 0x0A);
++
++    i2c_set8(dev, PCA9554_POLARITY, 0xF5);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_POLARITY), ==, 0x05);
++
++    i2c_set8(dev, PCA9554_CONFIG, 0xF3);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_CONFIG), ==, 0x03);
++
++    /*
++     * With all four pins as outputs, driving 0xFF only affects the low
++     * nibble.
++     */
++    i2c_set8(dev, PCA9554_POLARITY, 0x00);
++    i2c_set8(dev, PCA9554_CONFIG, 0x00);
++    i2c_set8(dev, PCA9554_OUTPUT, 0xFF);
++    g_assert_cmphex(i2c_get8(dev, PCA9554_INPUT), ==, 0x0F);
++}
++
+ static void pca9554_register_nodes(void)
+ {
+     QOSGraphEdgeOptions opts = {
+@@ -148,6 +208,16 @@ static void pca9554_register_nodes(void)
+     qos_add_test("polarity-with-output", "pca9554", test_polarity_with_output,
+                  NULL);
+     qos_add_test("no-autoincrement", "pca9554", test_no_autoincrement, NULL);
++
++    qos_node_create_driver("pca9536", i2c_device_create);
++    qos_node_consumes("pca9536", "i2c-bus", &opts);
++
++    qos_add_test("reset-defaults", "pca9536", test_pca9536_reset_defaults,
++                 NULL);
++    qos_add_test("output-drives-input", "pca9536",
++                 test_pca9536_output_drives_input, NULL);
++    qos_add_test("ignores-upper-bits", "pca9536",
++                 test_pca9536_ignores_upper_bits, NULL);
+ }
+ 
+ libqos_init(pca9554_register_nodes);
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0630-hw-arm-catalina-model-PCA9555-IO-expanders-with-thei.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0630-hw-arm-catalina-model-PCA9555-IO-expanders-with-thei.patch
@@ -1,0 +1,93 @@
+From 214ba4acb90892eb7f0ff78b08facecbb314a8b3 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:16 +0200
+Subject: [PATCH 630/631] hw/arm: catalina: model PCA9555 IO expanders with
+ their own type
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Catalina BMC device tree describes several IO expanders as nxp,pca9555.
+These were previously instantiated as PCA9552 devices as no PCA9555 model
+existed. Now that a dedicated PCA9555 device is available, use it so the
+emulated IO expanders match the hardware.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Cédric Le Goater <clg@redhat.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-24-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/arm/aspeed_ast2600_catalina.c | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/hw/arm/aspeed_ast2600_catalina.c b/hw/arm/aspeed_ast2600_catalina.c
+index 65495a524ea..f3b22e9aa9a 100644
+--- a/hw/arm/aspeed_ast2600_catalina.c
++++ b/hw/arm/aspeed_ast2600_catalina.c
+@@ -533,7 +533,7 @@ static void catalina_bmc_i2c_init(AspeedMachineState *bmc)
+                             TYPE_PCA9554, 0x27);
+     /* io_expander6 - pca9555@25 */
+     i2c_slave_create_simple(pca954x_i2c_get_bus(i2c_mux, 6),
+-                            TYPE_PCA9552, 0x25);
++                            TYPE_PCA9555, 0x25);
+     /* eeprom@51 */
+     at24c_eeprom_init_rom(pca954x_i2c_get_bus(i2c_mux, 6), 0x51, 8 * KiB,
+                           osfp_eeprom, osfp_eeprom_len);
+@@ -547,11 +547,11 @@ static void catalina_bmc_i2c_init(AspeedMachineState *bmc)
+ 
+     /* &i2c2 */
+     /* io_expander0 - pca9555@20 */
+-    i2c_slave_create_simple(i2c[2], TYPE_PCA9552, 0x20);
++    i2c_slave_create_simple(i2c[2], TYPE_PCA9555, 0x20);
+     /* io_expander0 - pca9555@21 */
+-    i2c_slave_create_simple(i2c[2], TYPE_PCA9552, 0x21);
++    i2c_slave_create_simple(i2c[2], TYPE_PCA9555, 0x21);
+     /* io_expander0 - pca9555@27 */
+-    i2c_slave_create_simple(i2c[2], TYPE_PCA9552, 0x27);
++    i2c_slave_create_simple(i2c[2], TYPE_PCA9555, 0x27);
+     /* eeprom@50 */
+     at24c_eeprom_init(i2c[2], 0x50, 8 * KiB);
+     /* eeprom@51 */
+@@ -572,13 +572,13 @@ static void catalina_bmc_i2c_init(AspeedMachineState *bmc)
+ 
+     /* &i2c6 */
+     /* io_expander3 - pca9555@21 */
+-    i2c_slave_create_simple(i2c[6], TYPE_PCA9552, 0x21);
++    i2c_slave_create_simple(i2c[6], TYPE_PCA9555, 0x21);
+     /* rtc@6f - nct3018y */
+     i2c_slave_create_simple(i2c[6], TYPE_DS1338, 0x6f);
+ 
+     /* &i2c9 */
+     /* io_expander4 - pca9555@4f */
+-    i2c_slave_create_simple(i2c[9], TYPE_PCA9552, 0x4f);
++    i2c_slave_create_simple(i2c[9], TYPE_PCA9555, 0x4f);
+     /* temperature-sensor@4b - tpm75 */
+     i2c_slave_create_simple(i2c[9], TYPE_TMP75, 0x4b);
+     /* eeprom@50 */
+@@ -615,17 +615,17 @@ static void catalina_bmc_i2c_init(AspeedMachineState *bmc)
+ 
+     /* &i2c14 */
+     /* io_expander9 - pca9555@10 */
+-    i2c_slave_create_simple(i2c[14], TYPE_PCA9552, 0x10);
++    i2c_slave_create_simple(i2c[14], TYPE_PCA9555, 0x10);
+     /* io_expander10 - pca9555@11 */
+-    i2c_slave_create_simple(i2c[14], TYPE_PCA9552, 0x11);
++    i2c_slave_create_simple(i2c[14], TYPE_PCA9555, 0x11);
+     /* io_expander11 - pca9555@12 */
+-    i2c_slave_create_simple(i2c[14], TYPE_PCA9552, 0x12);
++    i2c_slave_create_simple(i2c[14], TYPE_PCA9555, 0x12);
+     /* io_expander12 - pca9555@13 */
+-    i2c_slave_create_simple(i2c[14], TYPE_PCA9552, 0x13);
++    i2c_slave_create_simple(i2c[14], TYPE_PCA9555, 0x13);
+     /* io_expander13 - pca9555@14 */
+-    i2c_slave_create_simple(i2c[14], TYPE_PCA9552, 0x14);
++    i2c_slave_create_simple(i2c[14], TYPE_PCA9555, 0x14);
+     /* io_expander14 - pca9555@15 */
+-    i2c_slave_create_simple(i2c[14], TYPE_PCA9552, 0x15);
++    i2c_slave_create_simple(i2c[14], TYPE_PCA9555, 0x15);
+ 
+     /* &i2c15 */
+     /* temperature-sensor@1f - tmp421 */
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-git/0631-hw-arm-catalina-add-NIC-and-FIO-temperature-sensors.patch
+++ b/meta-facebook/recipes-devtools/qemu/qemu-git/0631-hw-arm-catalina-add-NIC-and-FIO-temperature-sensors.patch
@@ -1,0 +1,86 @@
+From e5d3f5ac8633de310066f14862b17e4cac8ef8a5 Mon Sep 17 00:00:00 2001
+From: Emmanuel Blot <emmanuel.blot@free.fr>
+Date: Thu, 9 Jul 2026 17:23:17 +0200
+Subject: [PATCH 631/631] hw/arm: catalina: add NIC and FIO temperature sensors
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Model the temperature sensors described by the Catalina device tree that
+have existing QEMU device models but were not yet instantiated: the four
+IOB NIC TMP421 sensors behind the i2c0 PCA9546 muxes at 0x71 and 0x75, and
+the FIO remote TMP75 sensor at 0x4f on the i2c1 mux.
+
+Signed-off-by: Emmanuel Blot <emmanuel.blot@free.fr>
+Reviewed-by: Cédric Le Goater <clg@redhat.com>
+Link: https://lore.kernel.org/qemu-devel/20260709-catalina-upgrade-v1-25-82a63fead90c@free.fr
+Signed-off-by: Cédric Le Goater <clg@redhat.com>
+---
+ hw/arm/aspeed_ast2600_catalina.c | 30 +++++++++++++++++++++++-------
+ 1 file changed, 23 insertions(+), 7 deletions(-)
+
+diff --git a/hw/arm/aspeed_ast2600_catalina.c b/hw/arm/aspeed_ast2600_catalina.c
+index f3b22e9aa9a..f714c9d1b32 100644
+--- a/hw/arm/aspeed_ast2600_catalina.c
++++ b/hw/arm/aspeed_ast2600_catalina.c
+@@ -472,7 +472,16 @@ static void catalina_bmc_i2c_init(AspeedMachineState *bmc)
+ 
+     /* &i2c0 */
+     /* i2c-mux@71 (PCA9546) on i2c0 */
+-    i2c_slave_create_simple(i2c[0], TYPE_PCA9546, 0x71);
++    i2c_mux = i2c_slave_create_simple(i2c[0], TYPE_PCA9546, 0x71);
++
++    /* i2c0mux0ch0 */
++    /* IOB0 NIC0 temperature-sensor@1f - tmp421 */
++    i2c_slave_create_simple(pca954x_i2c_get_bus(i2c_mux, 0),
++                            TYPE_TMP421, 0x1f);
++    /* i2c0mux0ch2 */
++    /* IOB0 NIC1 temperature-sensor@1f - tmp421 */
++    i2c_slave_create_simple(pca954x_i2c_get_bus(i2c_mux, 2),
++                            TYPE_TMP421, 0x1f);
+ 
+     /* i2c-mux@72 (PCA9546) on i2c0 */
+     i2c_mux = i2c_slave_create_simple(i2c[0], TYPE_PCA9546, 0x72);
+@@ -489,7 +498,16 @@ static void catalina_bmc_i2c_init(AspeedMachineState *bmc)
+     i2c_slave_create_simple(i2c[0], TYPE_PCA9546, 0x73);
+ 
+     /* i2c-mux@75 (PCA9546) on i2c0 */
+-    i2c_slave_create_simple(i2c[0], TYPE_PCA9546, 0x75);
++    i2c_mux = i2c_slave_create_simple(i2c[0], TYPE_PCA9546, 0x75);
++
++    /* i2c0mux3ch0 */
++    /* IOB1 NIC0 temperature-sensor@1f - tmp421 */
++    i2c_slave_create_simple(pca954x_i2c_get_bus(i2c_mux, 0),
++                            TYPE_TMP421, 0x1f);
++    /* i2c0mux3ch2 */
++    /* IOB1 NIC1 temperature-sensor@1f - tmp421 */
++    i2c_slave_create_simple(pca954x_i2c_get_bus(i2c_mux, 2),
++                            TYPE_TMP421, 0x1f);
+ 
+     /* i2c-mux@76 (PCA9546) on i2c0 */
+     i2c_mux = i2c_slave_create_simple(i2c[0], TYPE_PCA9546, 0x76);
+@@ -544,6 +562,8 @@ static void catalina_bmc_i2c_init(AspeedMachineState *bmc)
+                           fio_eeprom, fio_eeprom_len);
+     /* temperature-sensor@4b - tmp75 */
+     i2c_slave_create_simple(pca954x_i2c_get_bus(i2c_mux, 7), TYPE_TMP75, 0x4b);
++    /* temperature-sensor@4f - tmp75 (FIO remote) */
++    i2c_slave_create_simple(pca954x_i2c_get_bus(i2c_mux, 7), TYPE_TMP75, 0x4f);
+ 
+     /* &i2c2 */
+     /* io_expander0 - pca9555@20 */
+@@ -564,11 +584,7 @@ static void catalina_bmc_i2c_init(AspeedMachineState *bmc)
+     /* eeprom@52 */
+     at24c_eeprom_init_rom(pca954x_i2c_get_bus(i2c_mux, 6), 0x52, 8 * KiB,
+                           hdd_eeprom, hdd_eeprom_len);
+-    /* i2c5mux0ch7 */
+-    /* ina230@40 - no model */
+-    /* ina230@41 - no model */
+-    /* ina230@44 - no model */
+-    /* ina230@45 - no model */
++    /* i2c5mux0ch7 - empty */
+ 
+     /* &i2c6 */
+     /* io_expander3 - pca9555@21 */
+-- 
+2.50.1
+

--- a/meta-facebook/recipes-devtools/qemu/qemu-master_git.inc
+++ b/meta-facebook/recipes-devtools/qemu/qemu-master_git.inc
@@ -92,6 +92,40 @@ SRC_URI += " \
            file://0012-Add-minerva.patch \
            "
 
+SRC_URI += " \
+           file://0601-hw-sensor-adc128d818-add-12-bit-8-channel-ADC-device.patch \
+           file://0602-tests-qtest-adc128d818-add-test-harness-and-register.patch \
+           file://0603-tests-qtest-adc128d818-test-voltage-and-temperature-.patch \
+           file://0604-tests-qtest-adc128d818-test-limit-interrupts.patch \
+           file://0605-tests-qtest-adc128d818-test-operating-modes-and-powe.patch \
+           file://0606-hw-arm-aspeed-anacapa-use-ASCII-in-comments.patch \
+           file://0607-hw-gpio-pca9552-register-types-with-DEFINE_TYPES.patch \
+           file://0608-hw-gpio-pca9552-move-PCA955xState-definition-out-of-.patch \
+           file://0609-hw-gpio-pca9552-rename-I2CSlave-member-to-parent_obj.patch \
+           file://0610-hw-gpio-pca9552-default-description-to-the-instantia.patch \
+           file://0611-hw-gpio-pca9552-declare-pca9555-device-as-an-alias-o.patch \
+           file://0612-hw-gpio-pca9552-use-the-Resettable-interface-instead.patch \
+           file://0613-hw-gpio-pca9552-apply-input-polarity-inversion-on-re.patch \
+           file://0614-hw-gpio-pca9552-conform-GPIO-command-handling-to-the.patch \
+           file://0615-hw-gpio-pca9552-expose-GPIO-pins-as-pin-d-QOM-proper.patch \
+           file://0616-tests-qtest-add-PCA9555-register-access-tests.patch \
+           file://0617-tests-qtest-pca9555-test-output-to-input-reflection-.patch \
+           file://0618-tests-qtest-pca9555-test-polarity-inversion.patch \
+           file://0619-tests-qtest-pca9555-test-auto-increment-and-command-.patch \
+           file://0620-tests-qtest-pca9552-test-behaviour-specific-to-the-L.patch \
+           file://0621-hw-gpio-pca9554-add-PCA9536-support.patch \
+           file://0622-hw-gpio-pca9554-add-hw-dir-property-honoring-the-con.patch \
+           file://0623-hw-gpio-pca9554-reflect-push-pull-outputs-in-the-inp.patch \
+           file://0624-hw-gpio-pca9554-expose-pin-d-as-a-string-property.patch \
+           file://0625-tests-qtest-add-PCA9554-register-access-tests.patch \
+           file://0626-tests-qtest-pca9554-test-output-to-input-reflection-.patch \
+           file://0627-tests-qtest-pca9554-test-polarity-inversion.patch \
+           file://0628-tests-qtest-pca9554-test-absence-of-command-auto-inc.patch \
+           file://0629-tests-qtest-pca9554-test-the-PCA9536-4-bit-variant.patch \
+           file://0630-hw-arm-catalina-model-PCA9555-IO-expanders-with-thei.patch \
+           file://0631-hw-arm-catalina-add-NIC-and-FIO-temperature-sensors.patch \
+           "
+
 QEMU_CHECKOUT_DIR = "${BPN}-${PV}"
 QEMU_CHECKOUT_DIR:openbmc-fb-dunfell = "git"
 QEMU_CHECKOUT_DIR:openbmc-fb-kirkstone = "git"


### PR DESCRIPTION
Summary:
hw/arm: improve Aspeed Catalina BMC emulation

This series improves emulation of the Aspeed-based Catalina BMC machine,
mostly around its I2C buses: the GPIO expanders the board relies on and
the temperature sensors sitting next to them.

The bulk of the work is on the PCA95xx I/O expander models. The existing
PCA9552 and PCA9554 drivers only really covered the exact parts a couple
of boards happened to use, and some of their register and pin behaviour
did not match the datasheets. Catalina needs a few more variants and
expects them to act like the real chips, so:

 - the PCA9552 driver now provides proper PCA9555/PCA9535 types, applies
   input polarity inversion on reads, and handles the command register
   as the datasheet describes (auto-increment and wrapping);

 - the PCA9554 driver gains the 4-bit PCA9536 variant, reflects
push-pull
   outputs back into the input register, and grows an opt-in mode that
   honours the configured pin direction instead of forcing pins to
   outputs;

 - both drivers expose each line as a "pinN" QOM property, which lets an
   external actor drive an input pin. The property also allows reading
   the value driven onto an output-configured pin, which is the more
   useful capability, but nothing exercises it yet.

Along the way both models get a fair bit of cleanup (DEFINE_TYPES, the
Resettable interface, state moved out of the headers, default
descriptions derived from the instantiated type).

On the machine itself, Catalina now instantiates its PCA9555 expanders
as their own type, gains the NIC and FIO temperature sensors present on
real hardware, and drives the pca9554 expander input pins from outside
the guest.

Finally, the register-level behaviour of both expanders is covered by
new qtests.

Test Plan:
Run QEMU with a Catalina flash image:

./facebook/start-qemu --pkg-dir rebuild-docker -f .../flash-catalina

Reviewed By: ifel, jamesatha

Differential Revision: D114236127
