### PR TITLE
elbert weutil: bound fscanf field width when reading local MAC

### DIFF
--- a/meta-facebook/meta-elbert/recipes-utils/wedge-eeprom/files/utils/elbert_weutil.c
+++ b/meta-facebook/meta-elbert/recipes-utils/wedge-eeprom/files/utils/elbert_weutil.c
@@ -32,7 +32,7 @@ void read_local_mac(char *buffer)
   sprintf(buffer, "NA");
   fp = fopen(BMC_MGMT_MACADDR, "r");
   if (fp){
-     fscanf(fp, "%s", buffer);
+     fscanf(fp, "%19s", buffer);
      fclose(fp);
   }
   return;


### PR DESCRIPTION
## Problem

`read_local_mac()` in `elbert_weutil.c` reads the management MAC address with:

```c
fscanf(fp, "%s", buffer);
```

`%s` has no field-width limit, so a longer-than-expected token in `/sys/class/net/eth0/address` would overflow `buffer`. The only caller passes `char local_mac[20]`, so the buffer holds at most 19 characters plus the NUL terminator.

## Fix

Bound the field width to match the buffer:

```c
fscanf(fp, "%19s", buffer);
```

A real MAC address (17 chars, e.g. `00:11:22:33:44:55`) still fits, but the read can no longer overflow the buffer if the sysfs node ever returns a longer token.

Fixes #126.