### PR TITLE
nexthopbmc: u-boot: set mac3 rx/tx clock delays

### DIFF
--- a/meta-facebook/meta-nexthopbmc/recipes-bsp/u-boot/files/0002-Set-rx-and-tx-delay-for-mac3.patch
+++ b/meta-facebook/meta-nexthopbmc/recipes-bsp/u-boot/files/0002-Set-rx-and-tx-delay-for-mac3.patch
@@ -1,7 +1,7 @@
 From 47242a8f293029012ae0864f91984b0160b757d9 Mon Sep 17 00:00:00 2001
 From: Nate White <nate@nexthop.ai>
 Date: Thu, 2 Apr 2026 15:59:52 +0100
-Subject: [PATCH] Set rx delay to 0x1a which is 0x
+Subject: [PATCH] Set rx and tx delay for mac3
 
 Signed-off-by: Nate White <nate@nexthop.ai>
 ---
@@ -17,7 +17,7 @@ index 625ce755..a95fda4e 100644
  };
  
 +&scu {
-+	mac3-clk-delay = <0x1a 0x00 /* 1000 Mbps (Gigabit) RX and TX delay */
++	mac3-clk-delay = <0x00 0x00 /* 1000 Mbps (Gigabit) RX and TX delay */
 +			  0x08 0x04 /* 100 Mbps (Fast Eth) RX and TX delay */
 +			  0x08 0x04>; /* 10 Mbps (Ethernet)  RX and TX delay */
 +};

--- a/meta-facebook/meta-nexthopbmc/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-facebook/meta-nexthopbmc/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -19,5 +19,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://facebook-fblite_defconfig.append \
             file://0001-Use-correct-UART-for-nexthopbmc.patch \
-            file://0001-Set-rx-delay-to-0x1a-which-is-0x.patch \
+            file://0002-Set-rx-and-tx-delay-for-mac3.patch \
            "


### PR DESCRIPTION
# Description

Zero out the gigabit RX delay (was 0x1a) and rename the u-boot dts patch to describe what it actually does. Note that this is refered to as "mac3" in the dts, but this is MAC4 as described in the datasheet.

# Motivation

We need to set 0 TX delay and 0 RX delay, per instructions from hardware team.

# Test Plan

Boot up and observe traffic passing on eth0.

```
$ ssh root@bmc.lan
root@bmc.lan's password:
root@bmc:~# cat /etc/os-release
ID=openbmc-fb-master
NAME="Facebook OpenBMC Open Source"
VERSION="nexthopbmc-43331c794a-dirty (master)"
VERSION_ID=nexthopbmc-43331c794a-dirty
VERSION_CODENAME="master"
PRETTY_NAME="Facebook OpenBMC nexthopbmc-43331c794a-dirty (master)" CPE_NAME="cpe:/o:openembedded:openbmc-fb-master:nexthopbmc-43331c794a-dirty" root@bmc:~# ip -s link show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast
   state UP mode DEFAULT group default qlen 1000
    link/ether e8:e4:9d:00:c9:f9 brd ff:ff:ff:ff:ff:ff permaddr
76:03:4a:58:06:ef
    RX:  bytes packets errors dropped  missed   mcast
       1263166    9185      0    2085       0    4589
    TX:  bytes packets errors dropped carrier collsns
        589992    4687      0       0       0       0
root@bmc:~# ping -c 2 openwrt.lan
PING openwrt.lan (fdec:496d:1654::1): 56 data bytes
64 bytes from fdec:496d:1654::1: seq=0 ttl=64 time=0.795 ms
64 bytes from fdec:496d:1654::1: seq=1 ttl=64 time=0.822 ms

--- openwrt.lan ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss round-trip min/avg/max = 0.795/0.808/0.822 ms
```
