### PR TITLE
nexthopbmc: flashy: register nexthopbmc platform

### DIFF
--- a/tools/flashy/flash_procedure/flash_procedure_mappings.go
+++ b/tools/flashy/flash_procedure/flash_procedure_mappings.go
@@ -46,6 +46,7 @@ var GeneratedFlashProcedureMappings = map[string]func(step.StepParams) step.Step
 	"minipack":         flash.FlashCp,
 	"montblanc":        flash.FlashCp,
 	"morgan800cc":      flash.FlashCp,
+	"nexthopbmc":       flash.FlashCp,
 	"northdome":        flash.FlashCpVboot,
 	"rainiera6":        flash.FlashCp,
 	"rainiera7":        flash.FlashCp,

--- a/tools/flashy/lib/utils/bmc_lite_platforms.go
+++ b/tools/flashy/lib/utils/bmc_lite_platforms.go
@@ -13,5 +13,6 @@ var BMCLitePlatforms = []string{
 	"minipack3n",
 	"montblanc",
 	"morgan800cc",
+	"nexthopbmc",
 	"tahan",
 }

--- a/tools/platforms/platform_build_names
+++ b/tools/platforms/platform_build_names
@@ -34,6 +34,7 @@
   "minipack",
   "montblanc",
   "morgan800cc",
+  "nexthopbmc",
   "northdome",
   "rainiera6",
   "rainiera7",


### PR DESCRIPTION
# Description

Add nexthopbmc to the flashy BMC-lite platform list, the flash procedure mappings (FlashCp) and platform_build_names so flashy recognizes and flashes nexthopbmc images.
# Motivation

nexthopbmc targets should be able to be flashed with the flashy tool.

# Test Plan

Do an image upgrade:
```
./scripts/run_flashy_remote.sh \
      --host nexthopbmc-oob \
      --device mtd:flash0 \
      --imagepath /srv/tftp/sync/flash-nexthopbmc
Running a remote upgrade on 'nexthopbmc-oob'  with image '/srv/tftp/sync/flash-nexthopbmc'
Continue (y/n)?y
path-to-flashy not provided, building flashy...
Making installation directories on OpenBMC...
Copying flashy...
Copying image...
Copying upgrade script...
Running upgrade...
Getting buildname of device
Buildname: nexthopbmc
<snip>
2026/09/08 07:07:10 Fetching image data for offset: 33554432, size: 13238
2026/09/08 07:07:10 Flashing image data for offset: 33554432, size: 13238
2026/09/08 07:07:11 Finished flashing image '/run/upgrade/image' on to flash device '/dev/mtd5'
2026/09/08 07:07:11 Verifying copy on flash device '/dev/mtd5' with image file '/run/upgrade/image'
2026/09/08 07:07:16 Finished verifying copy on flash device '/dev/mtd5' with image file '/run/upgrade/image'
2026/09/08 07:07:16 FlashCp succeeded
2026/09/08 07:07:16 Finished: flashy
Flashing succeeded. It is safe to reboot this system. Flashing complete, rebooting the device...
Connection to nexthopbmc-oob closed by remote host.
```

Flashy go tests pass:
```
nate@builder:~/bmc/nh-openbmc/tools/flashy$ go test 2026/09/08 14:35:18 Running command
'/home/nate/bmc/nh-openbmc/tools/flashy/scripts/calculate_test_coverage.sh' with 30s timeout
2026/09/08 14:35:19 stdout: 93.9
2026/09/08 14:35:19 Command
'/home/nate/bmc/nh-openbmc/tools/flashy/scripts/calculate_test_coverage.sh' exited with code 0 after 915.914042ms
PASS
ok      github.com/facebook/openbmc/tools/flashy        0.918s
```