### PR TITLE
nexthopbmc: register platform with CIT (tests2)

### DIFF
--- a/tests2/utils/platforms.py
+++ b/tests2/utils/platforms.py
@@ -34,6 +34,7 @@ PLATFORMS = [
     "minipack",
     "montblanc",
     "morgan800cc",
+    "nexthopbmc",
     "northdome",
     "rainiera6",
     "rainiera7",


### PR DESCRIPTION
# Description
Add "nexthopbmc" to the list of platforms tests2/cit_runner.py accepts for --platform, and create the (empty) tests/nexthopbmc package so test modules can be added to it. No tests are included in this change; they follow in separate changes grouped by area.
# Motivation
Needed so we can add tests to verify functionality on nexthopbmc

# Test Plan

On a nexthopbmc (M4062NHP), with tests2 copied to /run/tests2:

    $ python3 cit_runner.py --platform nexthopbmc --list-tests
    rc=0
    $ python3 cit_runner.py --platform nexthopbmc

    ----------------------------------------------------------------------
    Ran 0 tests in 0.000s

    NO TESTS RAN
    rc=0
