### PR TITLE
nexthopbmc: tests: add CIT version tests

### DIFF
--- a/tests2/tests/nexthopbmc/test_kernel_version.py
+++ b/tests2/tests/nexthopbmc/test_kernel_version.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Nexthop Systems Inc.
+#
+# This program file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
+import unittest
+
+from common.base_kernel_version_test import BaseKernelVersionTest
+
+
+class KernelVersionTest(BaseKernelVersionTest, unittest.TestCase):
+    def set_kernel_version(self):
+        self.kernel_version = "6.12"

--- a/tests2/tests/nexthopbmc/test_uboot_version_check.py
+++ b/tests2/tests/nexthopbmc/test_uboot_version_check.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Nexthop Systems Inc.
+#
+# This program file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
+import unittest
+
+from common.base_uboot_version_test import BaseUbootVersionCheck
+
+
+class UbootVersionCheck(BaseUbootVersionCheck, unittest.TestCase):
+    def set_uboot_version_check_params(self):
+        self.uboot_ver_regex = r"\"uboot_ver\":\s+\"(?P<uboot_ver>20\d{2}\.\d{2})\""

--- a/tests2/tests/nexthopbmc/test_yocto_version.py
+++ b/tests2/tests/nexthopbmc/test_yocto_version.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Nexthop Systems Inc.
+#
+# This program file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
+import unittest
+
+from common.base_yocto_version_test import BaseYoctoVersionTest
+
+
+class YoctoVersionTest(BaseYoctoVersionTest, unittest.TestCase):
+    def set_yocto_version(self):
+        self.yocto_version = "master"


### PR DESCRIPTION
# Description

Add basic version tests for nexthopbmc. Ths is checking the version of the Linux kernel, U-Boot, and Yocto release version meet the requiements for FB-Lite platforms

# Motivation
Ensure that nexthopbmc meets the requirements for FB-Lite and doesn't regress.

# Test Plan

Run on a nexthopbmc with tests2 copied to /run/tests2:

    $ python3 cit_runner.py --run-test tests.nexthopbmc.test_kernel_version
    test_kernel_version (tests.nexthopbmc.test_kernel_version.KernelVersionTest.test_kernel_version) ... ok

    ----------------------------------------------------------------------
    Ran 1 test in 0.020s

    OK

    $ python3 cit_runner.py --run-test tests.nexthopbmc.test_uboot_version_check
    test_uboot_version_check (tests.nexthopbmc.test_uboot_version_check.UbootVersionCheck.test_uboot_version_check) ... ok

    ----------------------------------------------------------------------
    Ran 1 test in 0.011s

    OK

    $ python3 cit_runner.py --run-test tests.nexthopbmc.test_yocto_version
    test_yocto_version (tests.nexthopbmc.test_yocto_version.YoctoVersionTest.test_yocto_version) ... ok

    ----------------------------------------------------------------------
    Ran 1 test in 0.045s

    OK



Please include a summary of the change and which issue is fixed.



Please include an explanation of why you these changes are necessary

# Test Plan

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
